### PR TITLE
feat(cli): check for Tkinter in pn doctor

### DIFF
--- a/src/pythonnative/project/doctor.py
+++ b/src/pythonnative/project/doctor.py
@@ -61,8 +61,17 @@ def _which_version(tool: str, version_args: List[str]) -> Optional[str]:
     return text[0] if text else path
 
 
+def _tkinter_available() -> bool:
+    """Return whether the host Python can import Tkinter."""
+    try:
+        import tkinter  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def check_common() -> List[CheckResult]:
-    """Run platform-agnostic checks (interpreter, Pillow).
+    """Run platform-agnostic checks (interpreter and optional dependencies).
 
     Returns:
         Check results for the host Python and optional dependencies.
@@ -87,6 +96,17 @@ def check_common() -> List[CheckResult]:
                 "Pillow (icon/splash generation)",
                 WARN,
                 "not installed; run: pip install 'pythonnative[build]'",
+            )
+        )
+    if _tkinter_available():
+        results.append(CheckResult("Tkinter (desktop preview)", OK))
+    else:
+        results.append(
+            CheckResult(
+                "Tkinter (desktop preview)",
+                WARN,
+                "not installed; macOS: brew install python-tk; Debian/Ubuntu: sudo apt-get install python3-tk; "
+                "Windows: reinstall Python with the 'tcl/tk' option checked",
             )
         )
     return results

--- a/tests/project/test_doctor.py
+++ b/tests/project/test_doctor.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from pytest import MonkeyPatch
+
 from pythonnative.project import doctor
 from pythonnative.project.config import render_default_toml
 
@@ -43,6 +45,22 @@ def test_common_checks_present(tmp_path: Path) -> None:
     names = [r.name for r in results]
     assert any("Python" in n for n in names)
     assert any("Pillow" in n for n in names)
+    assert "Tkinter (desktop preview)" in names
+
+
+def test_common_check_reports_available_tkinter(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "_tkinter_available", lambda: True)
+    result = next(r for r in doctor.check_common() if r.name == "Tkinter (desktop preview)")
+    assert result.level == doctor.OK
+    assert result.detail == ""
+
+
+def test_common_check_reports_missing_tkinter(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "_tkinter_available", lambda: False)
+    result = next(r for r in doctor.check_common() if r.name == "Tkinter (desktop preview)")
+    assert result.level == doctor.WARN
+    assert "python3-tk" in result.detail
+    assert "tcl/tk" in result.detail
 
 
 def test_worst_level() -> None:


### PR DESCRIPTION
## What

- Add a `Tkinter (desktop preview)` result to the common doctor checks.
- Report a warning with platform-specific install hints when Tkinter cannot be imported.
- Cover the available and missing dependency paths.

## Why

`pn preview` requires Tkinter, but `pn doctor` previously reported a healthy environment when Tkinter was unavailable.

## How

The check imports Tkinter lazily and follows the existing optional dependency result pattern. It remains a warning because mobile builds do not require the desktop preview.

## Testing

- `./scripts/check.sh`
- Ruff, Black, MyPy, package build, full pytest suite, and E2E coverage all pass.

## Risks/Impact

Low. The new import is local to `pn doctor`, and missing Tkinter does not change the command exit behavior beyond the existing warning path.

## Docs/Follow-ups

No documentation changes required. The warning reuses the platform install guidance already shown by `pn preview`.

Closes #23