### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/src/pythonnative/cli/pn.py
+++ b/src/pythonnative/cli/pn.py
@@ -34,6 +34,7 @@ import shutil
 import subprocess
 import sys
 import time
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -863,6 +864,12 @@ def _run_hot_reload(
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="pn", description="PythonNative CLI")
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"pn {pkg_version('pythonnative')}",
+    )
     subparsers = parser.add_subparsers()
 
     parser_init = subparsers.add_parser("init", help="Scaffold a new project")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,20 @@ def run_pn(args: List[str], cwd: str) -> "subprocess.CompletedProcess[str]":
     return subprocess.run(cmd, cwd=cwd, check=False, capture_output=True, text=True)
 
 
+def test_cli_version(tmp_path: Path) -> None:
+    result = run_pn(["--version"], str(tmp_path))
+
+    assert result.returncode == 0
+    assert result.stdout.strip().startswith("pn ")
+
+
+def test_cli_short_version_flag(tmp_path: Path) -> None:
+    result = run_pn(["-V"], str(tmp_path))
+
+    assert result.returncode == 0
+    assert result.stdout.strip().startswith("pn ")
+
+
 def test_cli_init_and_clean() -> None:
     tmpdir = tempfile.mkdtemp(prefix="pn_cli_test_")
     try:


### PR DESCRIPTION
## What

Adds `--version` and `-V` options to the `pn` CLI.

## Why

Users currently have no quick way to check the installed PythonNative version from the command line.

## How

Uses Python package metadata together with argparse's built-in `version` action.

## Testing

- Tested `pn --version`
- Tested `pn -V`
- Ran `pytest -q tests/test_cli.py`

## Risks/Impact

Minimal. This only adds new CLI flags and does not change existing commands.

Closes #20