### PR TITLE
docs(events,mutations,platform_metrics): add API reference pages

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,0 +1,24 @@
+# Events
+
+Event callbacks live in a process-wide registry keyed by a view's
+integer tag and the event name. The
+[`Reconciler`][pythonnative.reconciler.Reconciler] writes to it during a
+commit; platform handlers read from it when a native widget fires.
+
+::: pythonnative.events
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: source
+      filters: ["!^_"]
+
+## Next steps
+
+- See what carries the remaining, non-callable props in
+  [Mutation ops](mutations.md).
+- See how handlers wire a platform listener once, at creation, in
+  [Native views](native_views.md).
+- Read the other Python-side store the native layer reads on demand in
+  [Platform metrics](platform_metrics.md).
+- Follow a full commit end to end in
+  [Reconciliation](../concepts/reconciliation.md).

--- a/docs/api/mutations.md
+++ b/docs/api/mutations.md
@@ -1,0 +1,25 @@
+# Mutation ops
+
+Five record types describe every change to the native view tree:
+create, update, insert, destroy, and set frame. The
+[`Reconciler`][pythonnative.reconciler.Reconciler] emits them; the
+[`NativeViewRegistry`][pythonnative.native_views.NativeViewRegistry]
+applies them.
+
+::: pythonnative.mutations
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: source
+      filters: ["!^_"]
+
+## Next steps
+
+- See where the callables stripped from these payloads go in
+  [Events](events.md).
+- See how each op is applied to a concrete widget in
+  [Native views](native_views.md).
+- Read what handlers size themselves against in
+  [Platform metrics](platform_metrics.md).
+- Read the diffing pass that produces these lists in
+  [Reconciliation](../concepts/reconciliation.md).

--- a/docs/api/native_views.md
+++ b/docs/api/native_views.md
@@ -1,8 +1,9 @@
 # Native views
 
 The bridge between PythonNative's element tree and concrete native
-widgets. Each commit's diff is expressed as a flat list of mutation
-ops referencing integer tags, applied through a single
+widgets. Each commit's diff is expressed as a flat list of
+[mutation ops](mutations.md) referencing integer tags, applied through a
+single
 [`apply_mutations`][pythonnative.native_views.NativeViewRegistry.apply_mutations]
 call. Every element type maps to a
 [`ViewHandler`][pythonnative.native_views.base.ViewHandler]
@@ -20,21 +21,12 @@ the platform-specific handlers are registered lazily so importing
 
 ## Mutation ops
 
-::: pythonnative.mutations
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false
-      members_order: source
-      filters: ["!^_"]
+The op types themselves are documented in [Mutation ops](mutations.md).
 
 ## Event routing
 
-::: pythonnative.events
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false
-      members_order: source
-      filters: ["!^_"]
+The registry and its dispatch entry point are documented in
+[Events](events.md).
 
 ## Base classes
 
@@ -59,3 +51,7 @@ the platform-specific handlers are registered lazily so importing
 - Read the high-level model in
   [Native views (concept)](../concepts/native-views.md).
 - See how the reconciler drives handlers in [Reconciler](reconciler.md).
+- Read the op vocabulary handlers apply in [Mutation ops](mutations.md).
+- Read the callback registry handlers dispatch into in [Events](events.md).
+- Read the values handlers size themselves against in
+  [Platform metrics](platform_metrics.md).

--- a/docs/api/platform_metrics.md
+++ b/docs/api/platform_metrics.md
@@ -1,0 +1,29 @@
+# Platform metrics
+
+A small process-wide store for values only the screen host can observe:
+safe-area insets, viewport size, and keyboard height. The host publishes
+them as the platform reports changes, and view handlers read them on
+demand instead of receiving them through every measurement call.
+Everything here is in layout units, points on iOS and
+density-independent pixels on Android, so the values add directly to
+other layout-unit values without conversion. Most app code reaches this
+indirectly, through
+[`use_safe_area_insets`][pythonnative.use_safe_area_insets] and
+[`use_window_dimensions`][pythonnative.use_window_dimensions].
+
+::: pythonnative.platform_metrics
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: source
+      filters: ["!^_"]
+
+## Next steps
+
+- See the handlers that read these values in
+  [Native views](native_views.md).
+- See the ops that position a view once it's measured in
+  [Mutation ops](mutations.md).
+- See the other Python-side registry the native layer talks to in
+  [Events](events.md).
+- Use the hooks that wrap these in [Hooks](hooks.md).

--- a/docs/api/pythonnative.md
+++ b/docs/api/pythonnative.md
@@ -51,6 +51,9 @@ The reference is split per module so each page stays scannable:
 | Reconciler | [Reconciler](reconciler.md) | [`Reconciler`][pythonnative.reconciler.Reconciler] |
 | Native modules | [Native modules](native_modules.md) | `Camera`, `Location`, `FileSystem`, `Notifications` |
 | Native views | [Native views](native_views.md) | [`NativeViewRegistry`][pythonnative.native_views.NativeViewRegistry], [`ViewHandler`][pythonnative.native_views.base.ViewHandler] |
+| Mutation ops | [Mutation ops](mutations.md) | [`CreateOp`][pythonnative.mutations.CreateOp], [`UpdateOp`][pythonnative.mutations.UpdateOp], [`InsertOp`][pythonnative.mutations.InsertOp], [`DestroyOp`][pythonnative.mutations.DestroyOp], [`SetFrameOp`][pythonnative.mutations.SetFrameOp] |
+| Event routing | [Events](events.md) | [`EventRegistry`][pythonnative.events.EventRegistry], [`dispatch_event`][pythonnative.events.dispatch_event], [`extract_events`][pythonnative.events.extract_events] |
+| Platform metrics | [Platform metrics](platform_metrics.md) | [`SafeAreaInsets`][pythonnative.platform_metrics.SafeAreaInsets], [`WindowDimensions`][pythonnative.platform_metrics.WindowDimensions], [`subscribe`][pythonnative.platform_metrics.subscribe] |
 | Hot reload | [Hot reload](hot_reload.md) | [`FileWatcher`][pythonnative.hot_reload.FileWatcher], [`ModuleReloader`][pythonnative.hot_reload.ModuleReloader] |
 | Diagnostics | [Diagnostics](diagnostics.md) | [`HookOrderError`][pythonnative.HookOrderError], [`warn`][pythonnative.diagnostics.warn], [`is_dev`][pythonnative.diagnostics.is_dev], [`report_error`][pythonnative.diagnostics.report_error] |
 | Custom components SDK | [SDK](sdk.md) | [`Props`][pythonnative.sdk._components.Props], [`ViewHandler`][pythonnative.native_views.base.ViewHandler], [`native_component`][pythonnative.sdk._components.native_component], [`register_component`][pythonnative.sdk._components.register_component], [`element_factory`][pythonnative.sdk._components.element_factory] |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,9 @@ nav:
     - Navigation: api/navigation.md
     - Native modules: api/native_modules.md
     - Native views: api/native_views.md
+    - Mutation ops: api/mutations.md
+    - Events: api/events.md
+    - Platform metrics: api/platform_metrics.md
     - SDK: api/sdk.md
     - Hot reload: api/hot_reload.md
     - Diagnostics: api/diagnostics.md

--- a/src/pythonnative/platform_metrics.py
+++ b/src/pythonnative/platform_metrics.py
@@ -226,12 +226,15 @@ def reset_keyboard_height() -> None:
 # that natural height. Forcing our own height threw off the pill
 # geometry, so the Android handler defers entirely to the system.
 
-#: UIKit HIG tab-bar content height in points. The total bar reaches
-#: ``IOS_TAB_BAR_BASE_HEIGHT_PT + safe_area_insets.bottom`` so the
-#: pill background can extend over the home indicator. Apple's HIG
-#: places the tab bar flush with the screen edge and lets UIKit
-#: render its own internal padding for the home indicator.
 IOS_TAB_BAR_BASE_HEIGHT_PT: float = 49.0
+"""UIKit HIG tab-bar content height in points.
+
+The total bar reaches ``IOS_TAB_BAR_BASE_HEIGHT_PT +
+safe_area_insets.bottom`` so the pill background can extend over the
+home indicator. Apple's HIG places the tab bar flush with the screen
+edge and lets UIKit render its own internal padding for the home
+indicator.
+"""
 
 
 def ios_tab_bar_height() -> float:


### PR DESCRIPTION
## What

Three new API reference pages — `docs/api/events.md`, `docs/api/mutations.md`, `docs/api/platform_metrics.md` — plus nav entries, index rows, and the removal of two now-duplicate render blocks from `docs/api/native_views.md`.

Closes #24.

## Why

The issue describes all three modules as having "no page at all." That's true only for `platform_metrics`. `events` and `mutations` were already fully rendered as sections of `native_views.md` (`:32` and `:23`). Adding new pages without removing those blocks isn't a cosmetic duplication — it breaks CI: constructed in a scratch copy, it produces `Aborted with 49 warnings in strict mode!`, one `mkdocs_autorefs: Multiple primary URLs found` per symbol across all 13 public names in `events`, because two anchors leave autorefs unable to resolve any of the 21 site-wide references to them.

So the pure-addition task in the issue is really a small restructuring, which is what @owenthcarey confirmed.

## How (brief)

- Three new pages following `docs/api/reconciler.md`: title, one-paragraph summary, the
  mkdocstrings block with identical options and filters, then Next steps.
- The `:::` blocks for `mutations` and `events` are removed from `native_views.md`, leaving a
  one-line pointer under each existing heading, per @owenthcarey's direction on the issue.
- Nav entries sit directly after Native views rather than appended, keeping them adjacent to
  the page that points at them and inside the internals cluster.
- Per the second ask, all four pages cross-link: each new page's Next steps names the other two
  plus Native views, and Native views names all three.
- `IOS_TAB_BAR_BASE_HEIGHT_PT` is a documented public constant that mkdocstrings silently
  dropped, because `platform_metrics.py` was the only file in `src/pythonnative/` documenting an
  attribute with Sphinx-style `#:` comments, which griffe doesn't parse as a docstring.
  Converting four comment lines to a PEP 258 docstring, matching `events.py:27`, is a runtime
  no-op — value and type verified unchanged — and makes the constant render. The alternative,
  `show_if_no_docstring: true` on the page, would have surfaced every other undocumented
  attribute as a side effect.

## Testing

- `site/` deleted and rebuilt from clean, `mkdocs build --strict` exit 0.
- `./scripts/check.sh` passes end to end.
- Each page verified against its module's AST to render exactly the expected symbols with no typing leakage, and the HTML grepped for duplicate anchors: 34 symbols, each with exactly one, and zero left on `native_views`.
- **Cross-reference audit (Owen's ask):** all 25 references were traced through the generated HTML one by one. None needed editing — every reference names a symbol rather than a page, so autorefs re-pointed all 21 that render, and the remaining 4 live in the deliberately unrendered platform handler modules. One reference improved for free: `platform_metrics.py:153` pointed at `set_safe_area_insets`, which previously resolved to nothing.

## Risks/Impact

Anchors for the `events` and `mutations` symbols move from `api/native_views/` to the new pages.
Every in-repo reference re-points automatically, but an external bookmark or link to something
like `api/native_views/#pythonnative.events.dispatch_event` will still reach a valid page and
no longer reach that anchor. Unavoidable given the move, and the reason for keeping the two
pointer lines where the sections used to be.

## Docs/Follow-ups

Two disclosed additions beyond the acceptance criteria, both deliberate:

- Rows in `docs/api/pythonnative.md`'s "Where to look next" table for all three pages. The
  criteria don't mention it, but every other API page has a row, and a page absent from the
  index is a page readers won't find.
- The `native_views.md` intro now links "mutation ops" to the new page, since that prose
  promised content that has moved.