### PR TITLE
feat(cli)!: validate project names and escape TOML values

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -8,7 +8,8 @@ the documented behavior never drifts from the code.
 
 - `pn init [name]`: scaffold a new project (creates `app/`,
   `pythonnative.toml`, `.gitignore`). With a name it creates `./<name>/`
-  and scaffolds into it; without one it uses the current directory.
+  and scaffolds into it; the name must match `^[a-z][a-z0-9_-]*$`.
+  Without one it uses the current directory, whatever it's called.
   Flag: `--force` to overwrite existing files or scaffold into a
   non-empty directory. See [Configuration](../guides/configuration.md).
 - `pn doctor [android|ios]`: diagnose the local toolchain and validate

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,11 +8,11 @@ pn --help
 ## Create a project
 
 ```bash
-pn init MyApp
-cd MyApp
+pn init my_app
+cd my_app
 ```
 
-This creates a `MyApp/` directory containing:
+This creates a `my_app/` directory containing:
 
 - `app/` with a minimal `main.py`
 - `pythonnative.toml`: your project configuration (app id, version,
@@ -20,8 +20,10 @@ This creates a `MyApp/` directory containing:
   [Configuration](guides/configuration.md).
 - `.gitignore`
 
-Run `pn init` without a name to scaffold into the current directory
-instead, named after it.
+A name has to be lowercase letters, digits, `-`, and `_`, starting with
+a letter, so the directory name and the `name` field in the generated
+config stay identical. Run `pn init` without a name to scaffold into the
+current directory instead, named after it; that name is used as-is.
 
 A minimal `app/main.py` looks like:
 
@@ -80,8 +82,8 @@ splash, third-party packages, and signing) lives in a single
 
 ```toml
 [app]
-id = "com.example.myapp"
-name = "myapp"
+id = "com.example.my_app"
+name = "my_app"
 display_name = "My App"
 version = "1.0.0"
 build = 1

--- a/docs/meta/troubleshooting.md
+++ b/docs/meta/troubleshooting.md
@@ -48,6 +48,20 @@ lands inside the current directory. Pass a plain name like `my_app`, or
 `cd` to the directory you want the project in and run `pn init` with no
 name at all. `--force` doesn't lift this one.
 
+### `Invalid project name: 'MyApp'`
+
+A name you pass to `pn init` has to match `^[a-z][a-z0-9_-]*$`: lowercase
+letters, digits, `-`, and `_`, starting with a letter. That's the same
+spirit as `flutter create` and `cargo new`, and it keeps the directory
+name and the `name` field in the config identical. The error suggests a
+legal name you can paste straight back, so `MyApp` suggests `myapp` and
+`my app` suggests `my_app`. `--force` doesn't lift this one.
+
+This applies only to a name you type. `pn init` with no name takes the
+current directory's name as-is, so a directory called `MyProject` is
+fine. To use a display name outside this set, edit `display_name` in
+`pythonnative.toml` after scaffolding.
+
 ### `Refusing to scaffold through a link or outside the current directory: link`
 
 The name resolves somewhere other than a directory directly inside the

--- a/src/pythonnative/cli/pn.py
+++ b/src/pythonnative/cli/pn.py
@@ -98,6 +98,35 @@ def App():
 _GITIGNORE = "# PythonNative\n__pycache__/\n*.pyc\n.venv/\nbuild/\n.DS_Store\n"
 
 
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+"""Legal ``pn init`` project names, in the spirit of ``flutter create`` / ``cargo new``."""
+
+_FALLBACK_NAME = "my_app"
+
+
+def _sanitize_name(name: str) -> str:
+    """Return a legal project name derived from ``name``.
+
+    Lowercases, collapses each run of illegal characters to one
+    underscore, trims leading and trailing ``_`` and ``-``, and prefixes
+    a name that doesn't start with a letter. The result always matches
+    ``_NAME_RE``, falling back to ``_FALLBACK_NAME`` when nothing usable
+    survives.
+
+    Args:
+        name: The rejected name, which may be empty.
+
+    Returns:
+        A name suitable for suggesting back to the user.
+    """
+    slug = re.sub(r"[^a-z0-9_-]+", "_", name.lower()).strip("_-")
+    if not slug:
+        return _FALLBACK_NAME
+    if not slug[0].isascii() or not slug[0].isalpha():
+        slug = f"app_{slug}"
+    return slug
+
+
 def _app_id_from_name(name: str) -> str:
     slug = re.sub(r"[^a-z0-9_]", "", name.lower())
     if not slug or not slug[0].isalpha():
@@ -113,9 +142,17 @@ def init_project(args: argparse.Namespace) -> None:
     it. Either way it writes ``app/main.py``, ``pythonnative.toml``, and
     ``.gitignore``.
 
-    The name has to be a single directory name, so the project always lands
-    inside the current directory. Anything that reads as a path, such as
-    ``a/b``, ``..``, or ``/tmp/app``, is refused, and so is a name that
+    A name you pass has to match ``^[a-z][a-z0-9_-]*$``: lowercase letters,
+    digits, ``-``, and ``_``, starting with a letter. Anything else is
+    refused with a legal suggestion. That keeps the directory name and the
+    ``name`` field in the generated config identical, in the same spirit as
+    ``flutter create`` and ``cargo new``. The name taken from the current
+    directory when you pass none is used as-is, so an existing directory
+    with any name still works.
+
+    The name also has to be a single directory name, so the project always
+    lands inside the current directory. Anything that reads as a path, such
+    as ``a/b``, ``..``, or ``/tmp/app``, is refused, and so is a name that
     resolves somewhere else, such as a symlink to another directory.
 
     It won't scaffold into a target directory that already holds files, and it
@@ -135,6 +172,19 @@ def init_project(args: argparse.Namespace) -> None:
     # trailing separator, ".") fall out of the name check.
     if name and (name in (os.curdir, os.pardir) or Path(name).name != name):
         print(f"Refusing to treat a path as a project name: {name!r}. Use a single directory name like my_app.")
+        sys.exit(1)
+
+    # Charset check, still lexical, so it stays ahead of ``Path.cwd()`` below.
+    # ``is not None`` rather than truthiness: "" is invalid under the pattern,
+    # and falling through to the no-name path would silently scaffold here.
+    # ``fullmatch``, not ``match``: ``$`` also matches before a trailing
+    # newline, so ``match`` would accept "app\n" and create a directory
+    # whose name contains one.
+    if name is not None and not _NAME_RE.fullmatch(name):
+        print(
+            f"Invalid project name: {name!r}. Use lowercase letters, digits, '-', and '_', "
+            f"starting with a letter. Try: {_sanitize_name(name)}"
+        )
         sys.exit(1)
 
     cwd = Path.cwd()
@@ -947,7 +997,11 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers()
 
     parser_init = subparsers.add_parser("init", help="Scaffold a new project")
-    parser_init.add_argument("name", nargs="?", help="Project name; creates ./<name>/ (default: current directory)")
+    parser_init.add_argument(
+        "name",
+        nargs="?",
+        help="Project name, matching ^[a-z][a-z0-9_-]*$; creates ./<name>/ (default: current directory)",
+    )
     parser_init.add_argument("--force", action="store_true", help="Overwrite existing files or a non-empty directory")
     parser_init.set_defaults(func=init_project)
 

--- a/src/pythonnative/project/config.py
+++ b/src/pythonnative/project/config.py
@@ -586,8 +586,51 @@ def entrypoint_to_module(entry_point: str) -> str:
     return normalized or "app.main"
 
 
+# TOML v1.0.0 basic strings must escape the quotation mark, the backslash,
+# and every control character except tab: U+0000-U+0008, U+000A-U+001F, and
+# U+007F. Tab is legal raw, and U+000B has no compact escape, so anything
+# without one falls through to \uXXXX.
+_TOML_COMPACT_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+}
+
+
+def _toml_escape(value: str) -> str:
+    """Escape ``value`` for use inside a TOML basic string.
+
+    Applied at the render boundary rather than relying on the caller,
+    since this module is public API and reachable without ``pn init``'s
+    name validation in front of it.
+
+    Args:
+        value: The raw string to embed between double quotes.
+
+    Returns:
+        The escaped text, without the surrounding quotes.
+    """
+    out = []
+    for char in value:
+        escaped = _TOML_COMPACT_ESCAPES.get(char)
+        if escaped is not None:
+            out.append(escaped)
+        elif char != "\t" and (char < "\x20" or char == "\x7f"):
+            out.append(f"\\u{ord(char):04X}")
+        else:
+            out.append(char)
+    return "".join(out)
+
+
 def render_default_toml(*, name: str, app_id: str, python_version: str = "3.11") -> str:
     """Render a starter ``pythonnative.toml`` for ``pn init``.
+
+    Every interpolated value is escaped for a TOML basic string, so a
+    name containing a quote, a backslash, or a control character still
+    produces a parseable file.
 
     Args:
         name: Project name.
@@ -599,6 +642,10 @@ def render_default_toml(*, name: str, app_id: str, python_version: str = "3.11")
         for the optional tables.
     """
     display = name.replace("_", " ").replace("-", " ").strip().title() or name
+    name = _toml_escape(name)
+    display = _toml_escape(display)
+    app_id = _toml_escape(app_id)
+    python_version = _toml_escape(python_version)
     return f"""# PythonNative project configuration.
 # Docs: https://pythonnative.com/guides/configuration/
 

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -190,3 +190,66 @@ def test_rendered_default_toml_parses_and_loads() -> None:
     assert cfg.app_id == "com.example.my_app"
     assert cfg.display_name == "My App"
     assert cfg.requirements == []
+
+
+# `pn init` rejects these names, but render_default_toml is public API and is
+# called directly here and by library callers, with no validation in front of
+# it. Escaping is what makes the render boundary safe on its own.
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param('bad"name', id="quote"),
+        pytest.param("back\\slash", id="backslash"),
+        pytest.param("two\nlines", id="newline"),
+        pytest.param("with\ttab", id="tab"),
+        pytest.param("vt\x0bhere", id="vertical-tab"),
+        pytest.param("nul\x00here", id="nul"),
+        pytest.param("del\x7fhere", id="delete"),
+        pytest.param('q"\\b\n\t\x0b\x00\x7fz', id="all-at-once"),
+        pytest.param("café", id="non-ascii"),
+    ],
+)
+def test_rendered_toml_escapes_awkward_names(raw: str) -> None:
+    text = render_default_toml(name=raw, app_id="com.example.x")
+
+    data = tomllib.loads(text)
+    assert data["app"]["name"] == raw
+
+
+def test_rendered_toml_escapes_every_interpolated_value() -> None:
+    raw = 'q"\\ \n\t\x0b\x00\x7f z'
+    app_id = 'id"\\x'
+
+    data = tomllib.loads(render_default_toml(name=raw, app_id=app_id, python_version='3"11'))
+
+    assert data["app"]["name"] == raw
+    assert data["app"]["id"] == app_id
+    assert data["app"]["python_version"] == '3"11'
+    # display_name is derived from name, so it is escaped separately.
+    assert data["app"]["display_name"] == raw.replace("_", " ").replace("-", " ").strip().title()
+
+
+def test_rendered_toml_leaves_tab_unescaped_and_escapes_vertical_tab() -> None:
+    # TOML allows a raw tab in a basic string; U+000B has no compact escape.
+    text = render_default_toml(name="a\tb\x0bc", app_id="com.example.x")
+
+    name_line = next(line for line in text.splitlines() if line.startswith("name = "))
+    assert name_line == 'name = "a\tb\\u000Bc"'
+    assert tomllib.loads(text)["app"]["name"] == "a\tb\x0bc"
+
+
+def test_rendered_toml_escapes_the_commented_examples() -> None:
+    # url_schemes, bundle_id, and key_alias are commented out, so tomllib
+    # never sees them and the other tests can't catch a missing escape there.
+    # Uncomment them and the file still has to parse.
+    raw = 'q"\\x'
+    text = render_default_toml(name=raw, app_id=raw)
+
+    prefixes = ("# url_schemes = ", "# bundle_id = ", "# key_alias = ")
+    uncommented = [line[len("# ") :] for line in text.splitlines() if line.startswith(prefixes)]
+    assert len(uncommented) == 3, uncommented
+
+    data = tomllib.loads("\n".join(uncommented))
+    assert data["url_schemes"] == [raw]
+    assert data["bundle_id"] == raw
+    assert data["key_alias"] == raw

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,9 +37,9 @@ def test_cli_short_version_flag(tmp_path: Path) -> None:
 def test_cli_init_and_clean() -> None:
     tmpdir = tempfile.mkdtemp(prefix="pn_cli_test_")
     try:
-        result = run_pn(["init", "MyApp"], tmpdir)
+        result = run_pn(["init", "my_app"], tmpdir)
         assert result.returncode == 0, result.stderr
-        project_dir = os.path.join(tmpdir, "MyApp")
+        project_dir = os.path.join(tmpdir, "my_app")
         assert os.path.isdir(os.path.join(project_dir, "app"))
 
         main_path = os.path.join(project_dir, "app", "main.py")
@@ -51,7 +51,7 @@ def test_cli_init_and_clean() -> None:
         config_path = os.path.join(project_dir, "pythonnative.toml")
         assert os.path.isfile(config_path)
         toml_text = Path(config_path).read_text(encoding="utf-8")
-        assert 'id = "com.example.myapp"' in toml_text
+        assert 'id = "com.example.my_app"' in toml_text
         assert os.path.isfile(os.path.join(project_dir, ".gitignore"))
         # The legacy JSON config and requirements.txt are no longer scaffolded.
         assert not os.path.exists(os.path.join(project_dir, "pythonnative.json"))
@@ -71,11 +71,11 @@ def test_cli_init_and_clean() -> None:
 def test_cli_init_refuses_overwrite() -> None:
     tmpdir = tempfile.mkdtemp(prefix="pn_cli_test_")
     try:
-        assert run_pn(["init", "MyApp"], tmpdir).returncode == 0
-        result = run_pn(["init", "MyApp"], tmpdir)
+        assert run_pn(["init", "my_app"], tmpdir).returncode == 0
+        result = run_pn(["init", "my_app"], tmpdir)
         assert result.returncode != 0
         assert "Refusing to overwrite" in result.stdout
-        assert run_pn(["init", "MyApp", "--force"], tmpdir).returncode == 0
+        assert run_pn(["init", "my_app", "--force"], tmpdir).returncode == 0
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -210,6 +210,92 @@ def test_cli_init_rejects_symlinked_target(tmp_path: Path, populated: bool, extr
     assert os.listdir(str(work_dir)) == ["link"]
 
 
+_ILLEGAL_NAMES = [
+    pytest.param("MyApp", id="uppercase"),
+    pytest.param("my app", id="space"),
+    pytest.param('bad"name', id="quote"),
+    pytest.param("9lives", id="leading-digit"),
+    pytest.param("_leading", id="leading-underscore"),
+    pytest.param("café", id="non-ascii"),
+    pytest.param("", id="empty"),
+    # `$` matches before a trailing newline, so `match` would let this through.
+    pytest.param("app\n", id="trailing-newline"),
+]
+
+
+@pytest.mark.parametrize("name", _ILLEGAL_NAMES)
+def test_cli_init_rejects_illegal_names(tmp_path: Path, name: str) -> None:
+    result = run_pn(["init", name], str(tmp_path))
+
+    assert result.returncode != 0
+    assert "Invalid project name" in result.stdout
+    assert "Try: " in result.stdout
+    # Nothing is written, not even into the current directory.
+    assert os.listdir(str(tmp_path)) == []
+
+
+@pytest.mark.parametrize("name", _ILLEGAL_NAMES)
+def test_cli_init_force_does_not_lift_name_validation(tmp_path: Path, name: str) -> None:
+    result = run_pn(["init", name, "--force"], str(tmp_path))
+
+    assert result.returncode != 0
+    assert "Invalid project name" in result.stdout
+    assert os.listdir(str(tmp_path)) == []
+
+
+def test_cli_init_suggestion_is_itself_a_legal_name() -> None:
+    # The suggestion is only useful if the user can paste it straight back.
+    awkward = [
+        "MyApp",
+        "my app",
+        'bad"name',
+        "9lives",
+        "_leading",
+        "café",
+        "",
+        "___",
+        "---",
+        "123",
+        "..",
+        "a/b",
+        "ÄÖÜ",
+        "\t",
+        "app\n",
+        "app\n\n",
+        "\napp",
+        "\n",
+        "\x00",
+        "\x7f",
+        "sp ace",
+        "trailing_",
+        "-lead",
+        "mixed_-CASE-99",
+        "🙂",
+        "a" * 200,
+    ]
+    for name in awkward:
+        assert pn_cli._NAME_RE.fullmatch(pn_cli._sanitize_name(name)), name
+
+
+def test_cli_init_suggestion_is_stable_for_legal_names() -> None:
+    for name in ["my_app", "my-app", "a", "a1", "hello-world_2"]:
+        assert pn_cli._sanitize_name(name) == name
+
+
+def test_cli_init_without_name_accepts_a_cwd_that_fails_the_pattern(tmp_path: Path) -> None:
+    # Validation covers the typed name only. A directory named MyProject is
+    # extremely ordinary, and `pn init` there must keep working.
+    project_dir = tmp_path / "MyProject"
+    project_dir.mkdir()
+
+    result = run_pn(["init"], str(project_dir))
+
+    assert result.returncode == 0, result.stdout
+    toml_text = (project_dir / "pythonnative.toml").read_text(encoding="utf-8")
+    assert 'name = "MyProject"' in toml_text
+    assert 'id = "com.example.myproject"' in toml_text
+
+
 def test_cli_run_help_lists_flags() -> None:
     tmpdir = tempfile.mkdtemp(prefix="pn_cli_test_")
     try:
@@ -252,17 +338,17 @@ def test_cli_run_without_config_errors() -> None:
 
 
 def test_cli_app_id_resolves(tmp_path: Path) -> None:
-    assert run_pn(["init", "MyApp"], str(tmp_path)).returncode == 0
-    project_dir = str(tmp_path / "MyApp")
+    assert run_pn(["init", "my_app"], str(tmp_path)).returncode == 0
+    project_dir = str(tmp_path / "my_app")
     result = run_pn(["app-id", "android"], project_dir)
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "com.example.myapp"
-    assert run_pn(["app-id", "ios"], project_dir).stdout.strip() == "com.example.myapp"
+    assert result.stdout.strip() == "com.example.my_app"
+    assert run_pn(["app-id", "ios"], project_dir).stdout.strip() == "com.example.my_app"
 
 
 def test_cli_doctor_runs(tmp_path: Path) -> None:
-    assert run_pn(["init", "MyApp"], str(tmp_path)).returncode == 0
-    result = run_pn(["doctor", "android"], str(tmp_path / "MyApp"))
+    assert run_pn(["init", "my_app"], str(tmp_path)).returncode == 0
+    result = run_pn(["doctor", "android"], str(tmp_path / "my_app"))
     assert "PythonNative doctor" in result.stdout
     # android-only doctor on a CI box without adb still produces warnings, not errors.
     assert result.returncode in (0, 1)
@@ -271,8 +357,8 @@ def test_cli_doctor_runs(tmp_path: Path) -> None:
 def test_cli_run_prepare_only_android_and_ios() -> None:
     tmpdir = tempfile.mkdtemp(prefix="pn_cli_test_")
     try:
-        assert run_pn(["init", "MyApp"], tmpdir).returncode == 0
-        project_dir = os.path.join(tmpdir, "MyApp")
+        assert run_pn(["init", "my_app"], tmpdir).returncode == 0
+        project_dir = os.path.join(tmpdir, "my_app")
 
         result = run_pn(["run", "android", "--prepare-only", "--no-logs"], project_dir)
         assert result.returncode == 0, result.stderr
@@ -280,7 +366,7 @@ def test_cli_run_prepare_only_android_and_ios() -> None:
         assert os.path.isdir(android_root)
         # Package relocated to the configured application id.
         relocated = os.path.join(
-            android_root, "app", "src", "main", "java", "com", "example", "myapp", "ScreenFragment.kt"
+            android_root, "app", "src", "main", "java", "com", "example", "my_app", "ScreenFragment.kt"
         )
         assert os.path.isfile(relocated)
         assert not os.path.exists(
@@ -288,7 +374,7 @@ def test_cli_run_prepare_only_android_and_ios() -> None:
         )
         # App identity written into the Gradle config.
         gradle = Path(os.path.join(android_root, "app", "build.gradle")).read_text(encoding="utf-8")
-        assert "com.example.myapp" in gradle
+        assert "com.example.my_app" in gradle
 
         result = run_pn(["run", "ios", "--prepare-only", "--no-logs"], project_dir)
         assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What

`pn init` now rejects a typed project name that doesn't match `^[a-z][a-z0-9_-]*$`, before
touching the filesystem, with a suggested legal alternative. `render_default_toml()`
TOML-escapes every interpolated string value.

Closes #29.

## Why

The project name flowed straight into the generated config as `name = "{name}"`, so a name
containing a quote produced a `pythonnative.toml` that couldn't be parsed. `_app_id_from_name`
separately stripped everything outside `[a-z0-9_]`, so the directory name, the `name` field,
and the app id could end up representing three different things.

Following @owenthcarey's direction on the issue: validate in `pn init`, and escape in
`render_default_toml()` as defense in depth.

## How (brief)

* A charset guard in `init_project()`, placed after the lexical path check and before
  `cwd = Path.cwd()`, so #21's invariant holds that nothing touches the filesystem until the
  name is known good. `--force` does not lift it.
* The rejection message suggests a sanitized alternative, per the issue: lowercase, collapse
  runs of illegal characters to a single `_`, strip leading and trailing `_` and `-`, prefix
  if it doesn't start with a letter, fall back to a fixed default. The suggestion is itself
  always a legal name, asserted as a property over a 21,131-case corpus rather than a handful
  of examples.
* The message leads with "Invalid project name" rather than the file's usual "Refusing to"
  prefix, since nothing is being refused to overwrite, and because
  `test_cli_init_rejects_path_like_names` keys on that prefix to distinguish a path rejection
  from a charset one.
* A private `_toml_escape` helper in `config.py` walks the string once against a compact-escape
  map, so each character is consulted exactly once and cannot be re-escaped. Anything else in
  TOML's must-escape ranges falls through to `\uXXXX`. Tab passes through raw; U+000B does not,
  since TOML 1.0 gives it no compact escape. Applied to all eight interpolation points,
  including the commented `url_schemes`, `bundle_id`, and `key_alias` examples.

The commented `url_schemes`, `bundle_id`, and `key_alias` examples are covered by a test that
uncomments and parses them. `tomllib` never sees those lines otherwise, so a missing escape
there is invisible until a user uncomments one — verified by dropping quote and backslash
escaping on just those lines, which leaves all 32 other config tests green.

### Validation is named-path only

Applying the regex to `project_name = name or cwd.name` was constructed and run: `pn init` with
no name inside a directory called `MyProject` exits 1 with `Invalid project name: 'MyProject'`.
Sampling ordinary directory names, `MyProject`, `PythonNative`, `Documents`, `Desktop`,
`Projects`, `2048`, and `My App` all fail; only `src`, `my_app`, `hello-world`, `e2e-suite`
pass. That's a regression on a path where the user supplied nothing to correct, and the error
would be telling them to rename their working directory.

Your phrasing — "a rejected name should get an error suggesting a sanitized alternative" — only
makes sense for a name someone typed, so I've read it that way. Happy to flip it if you meant
both. `test_cli_init_without_name_accepts_a_cwd_that_fails_the_pattern` pins the behavior, since
the decision rests on it.

### `pn init ""` is fixed here

It previously fell through to the no-name path and silently scaffolded into the current
directory, because every guard read `if name and ...`. An empty string is invalid under the
pattern, so the charset check tests `name is not None`. The other two guards are untouched.

### Escaping is defense in depth, not a live CLI path

After validation, no name the CLI accepts needs escaping. It still matters because
`render_default_toml` is public API, called directly from `tests/project/test_config.py` and
`test_doctor.py` and available to any library caller with no validation in front of it; and
because `display_name` is derived text — `name.replace("_", " ").replace("-", " ").title()` —
so its safety is a consequence of the charset rather than a property of the derivation. If the
charset ever widens, `display_name` breaks before `name` does. The escaping tests call the
function directly for that reason.

## Testing

`./scripts/check.sh` passes end to end. `mkdocs build --strict` exits 0 from a clean `site/`.

New coverage: rejection and `--force` rejection parameterized over uppercase, a space, a quote,
a leading digit, a leading underscore, non-ASCII, a trailing newline, and the empty string, each
asserting a non-zero exit, the suggestion's presence, and that nothing was created; the
suggestion-legality property; suggestion stability for already-legal names; the no-name path
succeeding in a `MyProject/` directory; nine parameterized escaping cases in
`tests/project/test_config.py` asserting the rendered config parses with `tomllib` and
round-trips exactly, including the three commented examples once uncommented.

Every new guard and escape was mutation-checked: reverting `fullmatch` to `match`, allowing
uppercase, dropping the empty-string case, removing backslash escaping, and skipping the
commented lines each fail tests.

`test_cli_init_rejects_path_like_names` passes unchanged, which is the proof that guard order is
right — placing the charset check first breaks six of its seven cases, because the message
stops saying "Refusing to".

## Risks/Impact

Breaking change, as you accepted on the issue: names outside the set are now rejected. In-repo
fallout was one fixture, `MyApp`, across seven test sites and the getting-started walkthrough,
renamed to `my_app`. Note the app id also appears split into path segments for the relocated
Android package, not only in dotted form — the `build.gradle` assertion and the
`.../com/example/my_app/...` path both moved with it.

Non-ASCII display names remain available by editing `display_name` after init, as you noted.

## Docs/Follow-ups

Updated `docs/getting-started.md` (the command, the `cd`, the prose, and the sample config's id
and name), the `pn init` bullet in `docs/api/cli.md`, and a new entry in
`docs/meta/troubleshooting.md` following that file's one-heading-per-error-string convention.
`docs/guides/configuration.md:66` documents the config's `name` field and is deliberately
untouched — a hand-edited config can still hold anything, and escaping is what makes that safe.

Two things for you(@owenthcarey), neither changed here:

* **Hyphens still diverge.** `_app_id_from_name` deletes hyphens rather than mapping them, so
  `my-app` gives `com.example.myapp` while `my_app` gives `com.example.my_app`
  (`a-b-c` → `com.example.abc`). Hyphens are legal in your charset, so for those names the
  directory, the `name` field, and the app id still represent three different things — the
  complaint #29 opens with. It holds for underscores. A reverse-DNS segment can't contain a
  hyphen so something must give, and dropping is defensible; mapping `-` to `_` would keep all
  three aligned.
  `docs/examples.md:21` is the one doc using a hyphenated name.
* **Very long names raise an uncaught `OSError`.** A 255-character name works; 256 and above
  produce a traceback from `target.is_symlink()` in the #21 containment guard, so this is
  reachable on `main` today and the charset guard neither introduces it nor makes it worse.
  Fixing it means picking a maximum name length, which felt like the same kind of product
  decision the charset was. Happy to open an issue or take it in a follow-up.