### PR TITLE
feat(cli): add --json output to pn devices

### DIFF
--- a/src/pythonnative/cli/pn.py
+++ b/src/pythonnative/cli/pn.py
@@ -256,10 +256,21 @@ def devices_command(args: argparse.Namespace) -> None:
     """List connected devices, emulators, and simulators.
 
     Args:
-        args: Parsed namespace with optional ``platform``.
+        args: Parsed namespace with optional ``platform`` and ``json``.
     """
     platform: Optional[str] = getattr(args, "platform", None)
+    as_json: bool = getattr(args, "json", False)
     devices = devices_mod.list_devices(platform)
+
+    if as_json:
+        print(json.dumps([d.to_dict() for d in devices], indent=2))
+        if not devices:
+            print(
+                "No devices found. Start an emulator or connect a device.",
+                file=sys.stderr,
+            )
+        return
+
     if not devices:
         print("No devices found.")
         print("Android: start an emulator or connect a device with USB debugging enabled.")
@@ -897,6 +908,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     parser_devices = subparsers.add_parser("devices", help="List devices, emulators, and simulators")
     parser_devices.add_argument("platform", nargs="?", choices=["android", "ios"], help="Restrict to a platform")
+    parser_devices.add_argument("--json", action="store_true", help="Print JSON array to stdout for scripting")
     parser_devices.set_defaults(func=devices_command)
 
     parser_run = subparsers.add_parser("run", help="Build, install, and launch on a device/simulator")

--- a/src/pythonnative/project/devices.py
+++ b/src/pythonnative/project/devices.py
@@ -64,6 +64,22 @@ class Device:
             return self.state in ("booted", "shutdown")
         return self.state in ("booted", "connected")
 
+    def to_dict(self) -> Dict[str, str]:
+        """Return a JSON-serialisable dict of the device's public fields.
+
+        Returns:
+            A dict with keys ``identifier``, ``kind``, ``state``,
+            ``name``, ``platform``, and ``os_version``.
+        """
+        return {
+            "identifier": self.identifier,
+            "kind": self.kind,
+            "state": self.state,
+            "name": self.name,
+            "platform": self.platform,
+            "os_version": self.os_version,
+        }
+
     def format(self) -> str:
         """Return one aligned listing row for the CLI."""
         os_part = f" ({self.os_version})" if self.os_version else ""

--- a/tests/project/test_devices.py
+++ b/tests/project/test_devices.py
@@ -96,3 +96,24 @@ def test_find_device_prefers_ready() -> None:
         Device(platform="android", kind="device", identifier="two", name="Pixel", state="connected"),
     ]
     assert find_device(devices, "Pixel").identifier == "two"
+
+
+def test_device_to_dict() -> None:
+    device = Device(
+        platform="ios",
+        kind="simulator",
+        identifier="AAAA-1111",
+        name="iPhone 15",
+        os_version="iOS 17.5",
+        state="booted",
+    )
+    result = device.to_dict()
+    assert result == {
+        "identifier": "AAAA-1111",
+        "kind": "simulator",
+        "state": "booted",
+        "name": "iPhone 15",
+        "platform": "ios",
+        "os_version": "iOS 17.5",
+    }
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 import subprocess
@@ -278,3 +279,69 @@ def test_run_hot_reload_imports_top_level_watcher(
     )
 
     assert events == ["start", "stop"]
+
+
+# ---------------------------------------------------------------------------
+# pn devices --json
+# ---------------------------------------------------------------------------
+
+
+def test_devices_json_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from pythonnative.project.devices import Device
+
+    fake_devices = [
+        Device(
+            platform="android",
+            kind="emulator",
+            identifier="emulator-5554",
+            name="sdk_gphone64_arm64",
+            state="connected",
+        ),
+        Device(
+            platform="ios",
+            kind="simulator",
+            identifier="AAAA-1111",
+            name="iPhone 15",
+            os_version="iOS 17.5",
+            state="booted",
+        ),
+    ]
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", lambda platform=None: fake_devices)
+
+    args = argparse.Namespace(platform=None, json=True)
+    pn_cli.devices_command(args)
+
+    captured = capsys.readouterr()
+    import json
+
+    data = json.loads(captured.out)
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["identifier"] == "emulator-5554"
+    assert data[0]["platform"] == "android"
+    assert data[1]["identifier"] == "AAAA-1111"
+    assert data[1]["os_version"] == "iOS 17.5"
+    # No hint text on stdout.
+    assert "No devices" not in captured.out
+
+
+def test_devices_json_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", lambda platform=None: [])
+
+    args = argparse.Namespace(platform=None, json=True)
+    pn_cli.devices_command(args)
+
+    captured = capsys.readouterr()
+    import json
+
+    data = json.loads(captured.out)
+    assert data == []
+    # Hints go to stderr, not stdout.
+    assert "No devices" in captured.err
+


### PR DESCRIPTION
What
- Add a `--json` flag to `pn devices` for machine-readable JSON output on stdout.
- Add a `to_dict()` serialization method to the `Device` dataclass.

Why
- Makes device listing scriptable in CI and automation scripts without parsing human-readable table text.

How (brief)
- Added `Device.to_dict()` returning public fields (`identifier`, `kind`, `state`, `name`, `platform`, `os_version`).
- Updated `devices_command()` in `src/pythonnative/cli/pn.py` to serialize to JSON when `--json` is passed, routing hint messages to stderr and returning exit code 0 on empty results.
- Added unit tests for `to_dict()` in `tests/project/test_devices.py` and CLI tests in `tests/test_cli.py`.

Testing
- Unit tests added in `tests/project/test_devices.py` and `tests/test_cli.py`.

Risks/Impact
- Low risk; non-breaking enhancement. Default table formatting remains unchanged when `--json` is omitted.

Docs/Follow-ups
- None required.

Closes #22
