### PR TITLE
docs(events,mutations,platform_metrics): add API reference pages

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -1,0 +1,21 @@
+# Events
+
+Tag-based event routing between native views and Python callbacks.
+The reconciler strips callable props from view payloads and registers
+them in a Python-side registry keyed by `(tag, name)`. Native listeners
+dispatch through [`dispatch_event`][pythonnative.events.dispatch_event],
+meaning re-renders that only update closure identities don't trigger native
+calls across the bridge.
+
+::: pythonnative.events
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: source
+      filters: ["!^_"]
+
+## Next steps
+
+- See how native views are updated and wired in [Native views](native_views.md).
+- Read about mutation ops in [Mutations](mutations.md).
+- Learn about touch and gesture handling in [Gestures](gestures.md).

--- a/docs/api/mutations.md
+++ b/docs/api/mutations.md
@@ -1,0 +1,21 @@
+# Mutations
+
+Batched mutation protocol between the reconciler and native backends.
+During the commit phase, the reconciler produces an ordered list of
+mutation operations (`CreateOp`, `InsertOp`, `UpdateOp`, `SetFrameOp`,
+`DestroyOp`) referencing integer tags. The entire transaction is applied
+in a single batch via [`apply_mutations`][pythonnative.native_views.NativeViewRegistry.apply_mutations],
+minimizing bridge crossings.
+
+::: pythonnative.mutations
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: source
+      filters: ["!^_"]
+
+## Next steps
+
+- Read how the virtual view tree is diffed in [Reconciler](reconciler.md).
+- See how mutation operations map to platform widgets in [Native views](native_views.md).
+- Read the high-level reconciliation model in [Reconciliation](../concepts/reconciliation.md).

--- a/docs/api/native_views.md
+++ b/docs/api/native_views.md
@@ -18,24 +18,6 @@ the platform-specific handlers are registered lazily so importing
       members_order: source
       filters: ["!^_"]
 
-## Mutation ops
-
-::: pythonnative.mutations
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false
-      members_order: source
-      filters: ["!^_"]
-
-## Event routing
-
-::: pythonnative.events
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false
-      members_order: source
-      filters: ["!^_"]
-
 ## Base classes
 
 ::: pythonnative.native_views.base
@@ -56,6 +38,9 @@ the platform-specific handlers are registered lazily so importing
 
 ## Next steps
 
+- See the mutation ops protocol in [Mutations](mutations.md).
+- See tag-based event routing in [Events](events.md).
 - Read the high-level model in
   [Native views (concept)](../concepts/native-views.md).
 - See how the reconciler drives handlers in [Reconciler](reconciler.md).
+

--- a/docs/api/platform_metrics.md
+++ b/docs/api/platform_metrics.md
@@ -1,0 +1,19 @@
+# Platform metrics
+
+Platform-level metrics shared between screen hosts and native view handlers.
+The screen host writes window metrics, safe-area insets, and keyboard heights,
+which view handlers query on demand in layout units (`pt` on iOS, `dp` on Android)
+to size bars and insets correctly without manual threading through measurement signatures.
+
+::: pythonnative.platform_metrics
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      members_order: source
+      filters: ["!^_"]
+
+## Next steps
+
+- See how platform detection works in [Platform](platform.md).
+- Learn how screens host root views in [Screen](screen.md).
+- Read about platform and accessibility integration in the [Platform & Accessibility guide](../guides/platform-accessibility.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,9 @@ nav:
     - Navigation: api/navigation.md
     - Native modules: api/native_modules.md
     - Native views: api/native_views.md
+    - Events: api/events.md
+    - Mutations: api/mutations.md
+    - Platform metrics: api/platform_metrics.md
     - SDK: api/sdk.md
     - Hot reload: api/hot_reload.md
     - Diagnostics: api/diagnostics.md


### PR DESCRIPTION
What
- Add API reference pages for `pythonnative.events`, `pythonnative.mutations`, and `pythonnative.platform_metrics`.
- Wire the new pages into the `API Reference` section of `mkdocs.yml`.
- De-duplicate embedded blocks in `docs/api/native_views.md` in favor of dedicated pages.

Why
- These modules had docstrings ready for mkdocstrings but were missing standalone pages in the API reference.

How (brief)
- Created `docs/api/events.md`, `docs/api/mutations.md`, and `docs/api/platform_metrics.md` with module intros, mkdocstrings directives (`filters: ["!^_"]`), and "Next steps" cross-links.
- Updated `mkdocs.yml` navigation to include the three new pages.
- Verified that `mkdocs build --strict` builds cleanly with zero warnings or broken references.

Testing
- Ran `mkdocs build --strict` locally; site builds cleanly in strict mode.

Risks/Impact
- Low risk; documentation only.

Docs/Follow-ups
- None required.

Closes #24
