### PR TITLE
fix(project): escape project name in rendered pythonnative.toml

### DIFF
--- a/src/pythonnative/project/config.py
+++ b/src/pythonnative/project/config.py
@@ -56,6 +56,7 @@ key_alias = "myapp"
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -599,20 +600,25 @@ def render_default_toml(*, name: str, app_id: str, python_version: str = "3.11")
         for the optional tables.
     """
     display = name.replace("_", " ").replace("-", " ").strip().title() or name
+    escaped_app_id = json.dumps(app_id)
+    escaped_name = json.dumps(name)
+    escaped_display = json.dumps(display)
+    escaped_python_version = json.dumps(python_version)
+    comment_name = name.replace("\n", " ").replace("\r", " ")
     return f"""# PythonNative project configuration.
 # Docs: https://pythonnative.com/guides/configuration/
 
 [app]
-id = "{app_id}"
-name = "{name}"
-display_name = "{display}"
+id = {escaped_app_id}
+name = {escaped_name}
+display_name = {escaped_display}
 version = "1.0.0"
 build = 1
-python_version = "{python_version}"
+python_version = {escaped_python_version}
 orientation = "portrait"        # portrait | landscape | all
 entry_point = "app/main.py"
-# Custom URL schemes for deep links (e.g. "{name}" opens {name}://...).
-# url_schemes = ["{name}"]
+# Custom URL schemes for deep links (e.g. {escaped_name} opens {comment_name}://...).
+# url_schemes = [{escaped_name}]
 
 # Declare the device capabilities your app needs. A string becomes the
 # iOS permission prompt text; `true` uses a sensible default.
@@ -637,7 +643,7 @@ packages = []
 [ios]
 deployment_target = "13.0"
 # development_team = "ABCDE12345"
-# bundle_id = "{app_id}"
+# bundle_id = {escaped_app_id}
 
 [ios.signing]
 export_method = "development"   # development | ad-hoc | app-store | enterprise
@@ -652,5 +658,5 @@ target_sdk = 34
 
 [android.signing]
 # keystore = "release.keystore"
-# key_alias = "{name}"
+# key_alias = {escaped_name}
 """

--- a/tests/project/test_config.py
+++ b/tests/project/test_config.py
@@ -190,3 +190,12 @@ def test_rendered_default_toml_parses_and_loads() -> None:
     assert cfg.app_id == "com.example.my_app"
     assert cfg.display_name == "My App"
     assert cfg.requirements == []
+
+
+def test_rendered_default_toml_escapes_special_characters() -> None:
+    text = render_default_toml(name='bad"name\nwith\\backslash', app_id="com.example.myapp")
+    data = tomllib.loads(text)
+    cfg = AppConfig.from_dict(data)
+    assert cfg.name == 'bad"name\nwith\\backslash'
+    assert cfg.app_id == "com.example.myapp"
+    assert cfg.display_name == 'Bad"Name\nWith\\Backslash'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,21 @@ def test_cli_init_creates_named_directory(tmp_path: Path) -> None:
     assert os.listdir(str(tmp_path)) == ["my_app"]
 
 
+def test_cli_init_escapes_special_characters_in_toml(tmp_path: Path) -> None:
+    result = run_pn(["init", 'bad"name'], str(tmp_path))
+    assert result.returncode == 0, result.stderr
+
+    project_dir = tmp_path / 'bad"name'
+    config_path = project_dir / "pythonnative.toml"
+    assert config_path.is_file()
+
+    from pythonnative.project.config import AppConfig
+
+    cfg = AppConfig.load(project_dir)
+    assert cfg.name == 'bad"name'
+    assert cfg.app_id == "com.example.badname"
+
+
 def test_cli_init_without_name_uses_cwd(tmp_path: Path) -> None:
     project_dir = tmp_path / "widgets"
     project_dir.mkdir()


### PR DESCRIPTION
What
- Properly escape project names, display names, and app identifiers in `render_default_toml()`.
- Sanitize comments in the rendered `pythonnative.toml` template.

Why
- Project names containing double quotes, backslashes, or control characters produced malformed TOML files that could not be parsed by `tomllib`.

How (brief)
- Used `json.dumps()` to serialize string literals into the starter TOML template in `src/pythonnative/project/config.py`.
- Added unit tests in `tests/project/test_config.py` and CLI tests in `tests/test_cli.py`.

Testing
- `pytest tests/project/test_config.py -v` (22 passed)
- `pytest tests/test_cli.py -k test_cli_init -v` (20 passed)
- `ruff check` and `black` formatting checks passed.

Risks/Impact
- Low risk; non-breaking fix for template generation.

Docs/Follow-ups
- None required.

Closes #29
