### PR TITLE
feat(package): export get_platform

### DIFF
--- a/scripts/check-e2e-coverage.py
+++ b/scripts/check-e2e-coverage.py
@@ -159,6 +159,11 @@ INTENTIONAL_EXEMPTIONS: Set[str] = {
     # --------------------------------------------------------------
     "diagnostics",
     "HookOrderError",
+    # --------------------------------------------------------------
+    # Thin functional aliases: one-line wrappers over a value that is
+    # already covered elsewhere.
+    # --------------------------------------------------------------
+    "get_platform",  # thin functional alias of Platform.OS
 }
 
 

--- a/src/pythonnative/__init__.py
+++ b/src/pythonnative/__init__.py
@@ -162,7 +162,7 @@ from .navigation import (
     use_route,
 )
 from .net import HTTPError, Response, fetch
-from .platform import Platform
+from .platform import Platform, get_platform
 from .runtime import run_async, run_blocking
 from .screen import create_screen
 from .sdk import (
@@ -367,6 +367,7 @@ __all__ = [
     "diagnostics",
     # Platform
     "Platform",
+    "get_platform",
     # Custom-component SDK
     "Props",
     "ViewHandler",

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -6,6 +6,7 @@ from typing import Generator
 
 import pytest
 
+import pythonnative as pn
 from pythonnative.platform import Platform, _set_platform_for_test, get_platform
 
 
@@ -25,6 +26,10 @@ def test_default_platform_is_test() -> None:
 
 def test_get_platform_matches_os() -> None:
     assert get_platform() == Platform.OS
+
+
+def test_get_platform_exported_from_package() -> None:
+    assert pn.get_platform() == pn.Platform.OS
 
 
 def test_version_string_present() -> None:


### PR DESCRIPTION
What
- Re-export `get_platform` from the top-level `pythonnative` package.

Why
- `get_platform()` in `pythonnative.platform` is documented and unit-tested, but it was never added to `pythonnative/__init__.py`, so `pn.get_platform()` raised `AttributeError`. This makes the documented call work.

How (brief)
- `src/pythonnative/__init__.py`: import `get_platform` alongside `Platform` and add `"get_platform"` to `__all__`.
- `scripts/check-e2e-coverage.py`: add `get_platform` to `INTENTIONAL_EXEMPTIONS` (thin functional alias of `Platform.OS`, no device surface).
- `tests/test_platform.py`: add a test asserting `pn.get_platform() == pn.Platform.OS` through the package surface.

Testing
- ./scripts/check.sh passes; python scripts/check-e2e-coverage.py exits 0.

Risks/Impact
- Additive only. New public name, no behavior change to existing symbols.

Docs/Follow-ups
- None; existing docs already reference `pn.get_platform()`.

Closes #44
