### PR TITLE
feat(net): add concise __repr__ to Response

### DIFF
--- a/src/pythonnative/net.py
+++ b/src/pythonnative/net.py
@@ -77,6 +77,10 @@ class Response:
         """``True`` if the status is in the 2xx range."""
         return 200 <= self.status < 300
 
+    def __repr__(self) -> str:
+        cls = type(self).__name__
+        return f"{cls}(status={self.status}, url={self.url!r}, ok={self.ok}, content={len(self.content)} bytes)"
+
     def text(self, encoding: Optional[str] = None) -> str:
         """Decode ``content`` to ``str``.
 

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -118,6 +118,17 @@ def test_get_json(echo_server: str) -> None:
     assert resp.json() == {"ok": True}
 
 
+def test_repr_summarizes_body(echo_server: str) -> None:
+    async def run() -> Response:
+        return await fetch(echo_server + "/text")
+
+    resp = asyncio.run(run())
+    text = repr(resp)
+    assert "status=200" in text
+    assert f"{len(resp.content)} bytes" in text
+    assert resp.text() not in text
+
+
 def test_non_2xx_does_not_raise_but_keeps_body(echo_server: str) -> None:
     async def run() -> Response:
         return await fetch(echo_server + "/status/418")


### PR DESCRIPTION
What
- Add a custom `Response.__repr__` that summarizes the body as a byte count.

Why
- `Response` is a `@dataclass` with a `content: bytes` field, so the auto-generated repr dumps the entire response body. Logging or printing a `fetch` result against a real endpoint floods the console with raw bytes.

How (brief)
- `src/pythonnative/net.py`: define `Response.__repr__` returning `Response(status=..., url=..., ok=..., content=<n> bytes)`. Uses `type(self).__name__` so a subclass reprs with its own name.
- `tests/test_net.py`: add `test_repr_summarizes_body` (uses the existing echo-server fixture) asserting the repr contains the status and byte count but not the decoded body.

Testing
- ./scripts/check.sh passes.

Risks/Impact
- Changes the repr string only. No effect on `status`, `url`, `headers`, `content`, or any method. `Response` is not equality-compared anywhere (dataclass `eq` still auto-generated).

Docs/Follow-ups
- None.

Closes #43
