### PR TITLE
docs(mkdocs): mention pn preview in the hello-world example

### DIFF
--- a/docs/examples/hello-world.md
+++ b/docs/examples/hello-world.md
@@ -46,6 +46,24 @@ def App():
 
 ## Run it
 
+### Preview on desktop
+
+For the fastest feedback loop, run the example in the desktop preview
+before opening an emulator or simulator. The preview imports the real
+app code, so install the example's declared package first:
+
+```bash
+pip install emoji
+pn preview
+```
+
+A desktop window opens with `app/main.py`'s `App`. Edit a component,
+save, and the preview refreshes in place. See the
+[Desktop preview guide](../guides/desktop-preview.md) for platform
+notes and more options.
+
+### Run on a device or simulator
+
 From the project root:
 
 ```bash

--- a/docs/examples/hello-world.md
+++ b/docs/examples/hello-world.md
@@ -49,11 +49,12 @@ def App():
 ### Preview on desktop
 
 For the fastest feedback loop, run the example in the desktop preview
-before opening an emulator or simulator. The preview imports the real
-app code, so install the example's declared package first:
+before opening an emulator or simulator. The preview imports your real
+app code, so if your project declares packages in
+`[requirements].packages`, `pip install` them first. From the project
+root:
 
 ```bash
-pip install emoji
 pn preview
 ```
 


### PR DESCRIPTION
## Summary

Adds a short desktop preview section to the Hello World example docs before the device/simulator instructions.

## Why

Readers who land on the example page can now discover pn preview as the fastest iteration loop before using an emulator or simulator.

## Validation

- env XDG_CACHE_HOME=/Users/theo/Documents/Codex/pythonnative/.cache .venv/bin/mkdocs build --strict
- git diff --check

Closes #42