### PR TITLE
docs(navigation): fix use_route and Stack.Screen examples

### DIFF
--- a/docs/examples/navigation.md
+++ b/docs/examples/navigation.md
@@ -38,7 +38,7 @@ def ProfileScreen():
     route = pn.use_route()
     nav = pn.use_navigation()
     return pn.Column(
-        pn.Text(f"User #{route['params']['user_id']}", style={"font_size": 24}),
+        pn.Text(f"User #{route['user_id']}", style={"font_size": 24}),
         pn.Button("Back", on_press=nav.go_back),
         style={"spacing": 12, "padding": 16},
     )
@@ -56,7 +56,7 @@ def App():
 
 `nav.navigate("Profile", {...})` pushes onto the stack;
 `nav.go_back()` pops one frame. To replace the entire stack (e.g.,
-after login), use `nav.replace(...)`.
+after login), use `nav.reset(...)`.
 
 ## Tab navigator
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,15 +48,15 @@ def HomeScreen():
 @pn.component
 def DetailScreen():
     route = pn.use_route()
-    return pn.Text(f"Count was {route.params.get('count', 0)}", style={"padding": 16})
+    return pn.Text(f"Count was {route.get('count', 0)}", style={"padding": 16})
 
 
 @pn.component
 def App():
     return pn.NavigationContainer(
         Stack.Navigator(
-            Stack.Screen("Home", HomeScreen, options={"title": "Home"}),
-            Stack.Screen("Detail", DetailScreen, options={"title": "Detail"}),
+            Stack.Screen("Home", component=HomeScreen, options={"title": "Home"}),
+            Stack.Screen("Detail", component=DetailScreen, options={"title": "Detail"}),
             initial_route="Home",
         )
     )

--- a/docs/guides/navigation.md
+++ b/docs/guides/navigation.md
@@ -32,8 +32,8 @@ Stack = pn.create_stack_navigator()
 def App():
     return pn.NavigationContainer(
         Stack.Navigator(
-            Stack.Screen("Home", HomeScreen, options={"title": "Home"}),
-            Stack.Screen("Detail", DetailScreen, options={"title": "Detail"}),
+            Stack.Screen("Home", component=HomeScreen, options={"title": "Home"}),
+            Stack.Screen("Detail", component=DetailScreen, options={"title": "Detail"}),
             initial_route="Home",
         )
     )
@@ -60,8 +60,8 @@ Stack = pn.create_stack_navigator()
 def App():
     return pn.NavigationContainer(
         Stack.Navigator(
-            Stack.Screen("Home", HomeScreen, options={"title": "Home"}),
-            Stack.Screen("Detail", DetailScreen, options={"title": "Detail"}),
+            Stack.Screen("Home", component=HomeScreen, options={"title": "Home"}),
+            Stack.Screen("Detail", component=DetailScreen, options={"title": "Detail"}),
             initial_route="Home",
         )
     )
@@ -175,8 +175,8 @@ def MainTabs():
 def App():
     return pn.NavigationContainer(
         Stack.Navigator(
-            Stack.Screen("Tabs", MainTabs, options={"title": "Home"}),
-            Stack.Screen("Detail", DetailScreen, options={"title": "Detail"}),
+            Stack.Screen("Tabs", component=MainTabs, options={"title": "Home"}),
+            Stack.Screen("Detail", component=DetailScreen, options={"title": "Detail"}),
         )
     )
 ```

--- a/docs/guides/navigation.md
+++ b/docs/guides/navigation.md
@@ -104,8 +104,8 @@ Tab = pn.create_tab_navigator()
 def App():
     return pn.NavigationContainer(
         Tab.Navigator(
-            Tab.Screen("Home", HomeScreen, options={"title": "Home"}),
-            Tab.Screen("Settings", SettingsScreen, options={"title": "Settings"}),
+            Tab.Screen("Home", component=HomeScreen, options={"title": "Home"}),
+            Tab.Screen("Settings", component=SettingsScreen, options={"title": "Settings"}),
         )
     )
 ```
@@ -129,8 +129,8 @@ Drawer = pn.create_drawer_navigator()
 def App():
     return pn.NavigationContainer(
         Drawer.Navigator(
-            Drawer.Screen("Home", HomeScreen, options={"title": "Home"}),
-            Drawer.Screen("Profile", ProfileScreen, options={"title": "Profile"}),
+            Drawer.Screen("Home", component=HomeScreen, options={"title": "Home"}),
+            Drawer.Screen("Profile", component=ProfileScreen, options={"title": "Profile"}),
         )
     )
 
@@ -166,8 +166,8 @@ Tab = pn.create_tab_navigator()
 @pn.component
 def MainTabs():
     return Tab.Navigator(
-        Tab.Screen("Home", HomeScreen, options={"title": "Home"}),
-        Tab.Screen("Settings", SettingsScreen, options={"title": "Settings"}),
+        Tab.Screen("Home", component=HomeScreen, options={"title": "Home"}),
+        Tab.Screen("Settings", component=SettingsScreen, options={"title": "Settings"}),
     )
 
 


### PR DESCRIPTION
## Summary

Fixes broken navigation code examples across three docs pages so they match the real API in `src/pythonnative/navigation.py`.

## Changes

- **`docs/getting-started.md`**: `use_route()` returns the params dict directly — removed the extra `.params.` indirection. Fixed `Stack.Screen("Home", HomeScreen, ...)` to use the required keyword-only `component=` argument.
- **`docs/guides/navigation.md`**: same `Stack.Screen(...)` keyword-argument fix, applied at all three occurrences (lines ~35-36, ~63-64, ~178-179).
- **`docs/examples/navigation.md`**: fixed `route['params']['user_id']` → `route['user_id']` (params dict is already unwrapped). Replaced the reference to `nav.replace(...)`, which doesn't exist on the navigator handle, with `nav.reset(...)` — the correct method for resetting the stack.

## Verification

- `mkdocs build --strict` completes with no errors related to these files.
- Manually ran the corrected `getting-started.md` snippet (`HomeScreen`/`DetailScreen`/`App` with `use_route()` and `component=`) against the installed package — imports and defines cleanly with no errors.

Fixes #36