### PR TITLE
docs(platform): document the desktop OS value and is_desktop

### DIFF
--- a/docs/api/platform.md
+++ b/docs/api/platform.md
@@ -16,10 +16,12 @@ branches throughout the codebase.
 
 | Attribute | Values |
 |---|---|
-| `Platform.OS` | `"ios"`, `"android"`, or `"test"` |
+| `Platform.OS` | `"ios"`, `"android"`, `"desktop"` or `"test"` |
 | `Platform.Version` | Best-effort OS version string |
-| `Platform.is_ios` / `Platform.is_android` / `Platform.is_test` | Booleans |
+| `Platform.is_ios` / `Platform.is_android` / `Platform.is_test` / `Platform.is_desktop` | Booleans |
 | `Platform.select(spec, default=None)` | Pick a value matching the current platform |
+
+- `"desktop"` means the `pn preview` Tkinter backend.
 
 ## See also
 

--- a/docs/api/platform.md
+++ b/docs/api/platform.md
@@ -16,9 +16,9 @@ branches throughout the codebase.
 
 | Attribute | Values |
 |---|---|
-| `Platform.OS` | `"ios"`, `"android"`, `"desktop"` or `"test"` |
+| `Platform.OS` | `"ios"`, `"android"`, `"desktop"`, or `"test"` |
 | `Platform.Version` | Best-effort OS version string |
-| `Platform.is_ios` / `Platform.is_android` / `Platform.is_test` / `Platform.is_desktop` | Booleans |
+| `Platform.is_ios` / `Platform.is_android` / `Platform.is_desktop` / `Platform.is_test` | Booleans |
 | `Platform.select(spec, default=None)` | Pick a value matching the current platform |
 
 - `"desktop"` means the `pn preview` Tkinter backend.


### PR DESCRIPTION
What
- Updated the quick-reference table to include "desktop" in the Platform.OS row and add Platform.is_desktop to the booleans row, with a short note that "desktop" means the pn preview Tkinter backend. 

Why
- The quick-reference table in docs/api/platform.md (around line 19) says Platform.OS is "ios", "android", or "test", and only lists is_ios / is_android / is_test. Since the desktop preview backend landed, the code also reports "desktop" and exposes Platform.is_desktop (see src/pythonnative/platform.py, lines 39, 77-78, 83, and 94).

Testing
- No tests, only doc change

Risks/Impact
- No risks, only doc change

Docs/Follow-ups
- Docs updated

Closes #39 