### PR TITLE
docs(mkdocs): tell readers how to run the example snippets

### DIFF
--- a/docs/examples/counter.md
+++ b/docs/examples/counter.md
@@ -4,6 +4,9 @@ A counter with two buttons (increment and decrement), a reset, and a
 small bit of conditional styling. Practical introduction to
 [`use_state`][pythonnative.use_state] and event handlers.
 
+Paste it into `app/main.py` of a project scaffolded with `pn init`,
+then run `pn preview app.main.Counter`.
+
 ## The code
 
 ```python

--- a/docs/examples/forms.md
+++ b/docs/examples/forms.md
@@ -5,6 +5,9 @@ handler. Demonstrates [`TextInput`][pythonnative.TextInput],
 controlled patterns with [`use_state`][pythonnative.use_state], and
 how to wire submission.
 
+Paste it into `app/main.py` of a project scaffolded with `pn init`,
+then run `pn preview app.main.SignUp`.
+
 ## The code
 
 ```python

--- a/docs/examples/hello-world.md
+++ b/docs/examples/hello-world.md
@@ -5,7 +5,7 @@ The smallest possible PythonNative app. You'll learn how to:
 - Define a component with `@pn.component`.
 - Manage state with `use_state`.
 - Compose elements with `pn.Column`.
-- Run it with `pn run`.
+- Run it with `pn preview` and `pn run`.
 
 ## The code
 

--- a/docs/examples/lists.md
+++ b/docs/examples/lists.md
@@ -4,6 +4,9 @@ Render a dynamic list with [`FlatList`][pythonnative.FlatList], use
 keys for stable reconciliation, and hook in delete and toggle actions.
 This example builds a simple to-do list.
 
+Paste it into `app/main.py` of a project scaffolded with `pn init`,
+then run `pn preview app.main.TodoList`.
+
 ## The code
 
 ```python


### PR DESCRIPTION
What
- Added instructions to the Counter, Forms, and Lists example pages explaining how to run each snippet with `pn preview`.
- Updated the Hello World example introduction bullet to mention both `pn preview` and `pn run`.

Why
- Readers copying the code snippets into `app/main.py` and running `pn preview` would not see anything mount because the top-level components are named `Counter`, `SignUp`, and `TodoList` rather than `App`.
- Hello World's introduction bullet only mentioned `pn run` even though the page now leads with `pn preview`.

How (brief)
- Added a short sentence after the introductory paragraph in `docs/examples/counter.md`, `docs/examples/forms.md`, and `docs/examples/lists.md`, directing readers to use `pn preview app.main.Counter`, `pn preview app.main.SignUp`, and `pn preview app.main.TodoList`.
- Updated the bullet on line 8 of `docs/examples/hello-world.md` to reference both `pn preview` and `pn run`.

Testing
- Ran `uv run mkdocs build --strict` locally (passed with 0 errors).
- Ran `./scripts/check.sh` locally (all Ruff, Black, MyPy, pytest, and E2E coverage checks passed).

Risks/Impact
- None. Documentation-only change.

Docs/Follow-ups
- None.

Closes #52
