### PR TITLE
feat(cli): add --device flag to pn logs

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -26,7 +26,9 @@ the documented behavior never drifts from the code.
   simulator. Flags: `--device` (target a specific device by identifier
   or name), `--prepare-only`, `--hot-reload`, `--no-logs`.
 - `pn logs android|ios`: stream logs from the running app without
-  rebuilding.
+  rebuilding. Flag: `--device` (target a specific device by identifier
+  or name, same as `pn run`; physical iOS devices aren't supported for
+  log streaming — use Console.app or Xcode > Devices and Simulators).
 - `pn build android|ios`: build distributable artifacts (release by
   default). Flags: `--debug` for the debug variant, `--upload` to send
   an iOS release build to App Store Connect. See

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -27,8 +27,8 @@ the documented behavior never drifts from the code.
   or name), `--prepare-only`, `--hot-reload`, `--no-logs`.
 - `pn logs android|ios`: stream logs from the running app without
   rebuilding. Flag: `--device` (target a specific device by identifier
-  or name, same as `pn run`; physical iOS devices aren't supported for
-  log streaming — use Console.app or Xcode > Devices and Simulators).
+  or name, same as `pn run`). Physical iOS devices aren't supported for
+  log streaming; use Console.app or Xcode > Devices and Simulators.
 - `pn build android|ios`: build distributable artifacts (release by
   default). Flags: `--debug` for the debug variant, `--upload` to send
   an iOS release build to App Store Connect. See

--- a/src/pythonnative/cli/pn.py
+++ b/src/pythonnative/cli/pn.py
@@ -627,10 +627,15 @@ def logs_command(args: argparse.Namespace) -> None:
     """Stream logs from the running app without rebuilding.
 
     Args:
-        args: Parsed namespace (``platform``).
+        args: Parsed namespace (``platform``, ``device``).
     """
     platform: str = args.platform
+    device = _resolve_device(platform, getattr(args, "device", None))
     if platform == "android":
+        if device is not None:
+            # Both adb and logcat below honor ANDROID_SERIAL, so exporting
+            # it targets the whole log stream at the chosen device.
+            os.environ["ANDROID_SERIAL"] = device.identifier
         proc = _start_android_log_stream()
         if proc is None:
             sys.exit(1)
@@ -644,10 +649,13 @@ def logs_command(args: argparse.Namespace) -> None:
 
     # iOS: relaunch the app on the booted simulator with a console PTY so
     # Python's stdout/stderr stream to this terminal.
-    config = _load_config_or_exit()
-    proc = _start_ios_log_stream(config.bundle_id)
-    if proc is None:
+    if device is not None and device.kind == "device":
         print("For a physical device, use Console.app or Xcode > Devices and Simulators.")
+        sys.exit(1)
+    config = _load_config_or_exit()
+    udid = device.identifier if device is not None else None
+    proc = _start_ios_log_stream(config.bundle_id, udid=udid)
+    if proc is None:
         sys.exit(1)
     try:
         proc.wait()
@@ -763,16 +771,19 @@ def _select_ios_simulator() -> Optional[str]:
     return None
 
 
-def _start_ios_log_stream(bundle_id: str) -> Optional[subprocess.Popen]:
+def _start_ios_log_stream(bundle_id: str, *, udid: Optional[str] = None) -> Optional[subprocess.Popen]:
     """Re-launch the iOS app with a console PTY so its stdio streams here.
 
     Args:
         bundle_id: The app's bundle identifier.
+        udid: A specific simulator UDID to target. Falls back to the
+            booted simulator when not given.
 
     Returns:
         The launched process, or ``None`` when no simulator is booted.
     """
-    udid = _booted_ios_udid()
+    if udid is None:
+        udid = _booted_ios_udid()
     if udid is None:
         print("Note: no booted iOS Simulator found; skipping log streaming.")
         return None
@@ -1045,6 +1056,12 @@ def _build_parser() -> argparse.ArgumentParser:
 
     parser_logs = subparsers.add_parser("logs", help="Stream logs from the running app")
     parser_logs.add_argument("platform", choices=["android", "ios"])
+    parser_logs.add_argument(
+        "--device",
+        "-d",
+        help="Target device: an identifier or name from 'pn devices' "
+        "(physical iOS devices aren't supported for log streaming)",
+    )
     parser_logs.set_defaults(func=logs_command)
 
     parser_build = subparsers.add_parser("build", help="Build distributable artifacts")

--- a/src/pythonnative/cli/pn.py
+++ b/src/pythonnative/cli/pn.py
@@ -12,8 +12,8 @@ The console script `pn` (declared in `pyproject.toml`) dispatches to:
   simulators, as a table or as JSON with `--json`.
 - `pn run android|ios [--device D]`: stage + build + install + launch on
   a device, emulator, or simulator, with optional on-device hot reload.
-- `pn logs android|ios`: stream logs from the running app without
-  rebuilding.
+- `pn logs android|ios [--device D]`: stream logs from the running app
+  without rebuilding.
 - `pn build android|ios`: produce standalone artifacts (signed APK/AAB,
   or an iOS archive/IPA, optionally uploaded to App Store Connect).
 - `pn app-id android|ios`: print the resolved application/bundle id
@@ -656,6 +656,7 @@ def logs_command(args: argparse.Namespace) -> None:
     udid = device.identifier if device is not None else None
     proc = _start_ios_log_stream(config.bundle_id, udid=udid)
     if proc is None:
+        print("For a physical device, use Console.app or Xcode > Devices and Simulators.")
         sys.exit(1)
     try:
         proc.wait()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -620,6 +620,111 @@ def test_devices_json_serializes_awkward_field_values(
     }
 
 
+class _FakeCompletedProc:
+    """Stand-in for subprocess.Popen that returns immediately from wait()."""
+
+    def wait(self) -> int:
+        return 0
+
+
+def test_logs_command_android_sets_android_serial_for_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
+    monkeypatch.delenv("ANDROID_SERIAL", raising=False)
+    monkeypatch.setattr(pn_cli, "_start_android_log_stream", lambda: _FakeCompletedProc())
+
+    pn_cli.logs_command(argparse.Namespace(platform="android", device="Pixel"))
+
+    assert os.environ["ANDROID_SERIAL"] == "R5CT12345XYZ"
+
+
+def test_logs_command_android_no_device_leaves_android_serial_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
+    monkeypatch.delenv("ANDROID_SERIAL", raising=False)
+    monkeypatch.setattr(pn_cli, "_start_android_log_stream", lambda: _FakeCompletedProc())
+
+    pn_cli.logs_command(argparse.Namespace(platform="android", device=None))
+
+    assert "ANDROID_SERIAL" not in os.environ
+
+
+def test_logs_command_ios_passes_resolved_udid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
+    monkeypatch.setattr(
+        pn_cli, "_load_config_or_exit", lambda project_dir=None: argparse.Namespace(bundle_id="com.example.app")
+    )
+    captured: Dict[str, Optional[str]] = {}
+
+    def _fake_start_ios_log_stream(bundle_id: str, *, udid: Optional[str] = None) -> _FakeCompletedProc:
+        captured["bundle_id"] = bundle_id
+        captured["udid"] = udid
+        return _FakeCompletedProc()
+
+    monkeypatch.setattr(pn_cli, "_start_ios_log_stream", _fake_start_ios_log_stream)
+
+    pn_cli.logs_command(argparse.Namespace(platform="ios", device="iPhone 17"))
+
+    assert captured == {"bundle_id": "com.example.app", "udid": "ABC-123"}
+
+
+def test_logs_command_ios_no_device_falls_back_to_booted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
+    monkeypatch.setattr(
+        pn_cli, "_load_config_or_exit", lambda project_dir=None: argparse.Namespace(bundle_id="com.example.app")
+    )
+    captured: Dict[str, Optional[str]] = {}
+
+    def _fake_start_ios_log_stream(bundle_id: str, *, udid: Optional[str] = None) -> _FakeCompletedProc:
+        captured["udid"] = udid
+        return _FakeCompletedProc()
+
+    monkeypatch.setattr(pn_cli, "_start_ios_log_stream", _fake_start_ios_log_stream)
+
+    pn_cli.logs_command(argparse.Namespace(platform="ios", device=None))
+
+    assert captured["udid"] is None
+
+
+def test_logs_command_ios_physical_device_prints_console_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    physical = Device("ios", "device", "PHYS-1", "Owen's iPhone", "iOS 26.4", "connected")
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices([physical]))
+
+    with pytest.raises(SystemExit) as exc_info:
+        pn_cli.logs_command(argparse.Namespace(platform="ios", device="Owen's iPhone"))
+
+    assert exc_info.value.code == 1
+    assert "Console.app" in capsys.readouterr().out
+
+
+def test_logs_command_bad_device_query_exits_with_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
+
+    with pytest.raises(SystemExit) as exc_info:
+        pn_cli.logs_command(argparse.Namespace(platform="android", device="nope"))
+
+    assert exc_info.value.code == 1
+    assert "no android device matches 'nope'" in capsys.readouterr().out
+
+
+def test_logs_device_flag_is_wired_through_argparse(tmp_path: Path) -> None:
+    # The tests above call logs_command() directly; this one proves the
+    # subparser actually accepts --device and routes it through.
+    env = {**os.environ, "PATH": str(tmp_path)}
+    result = run_pn(["logs", "android", "--device", "nope"], str(tmp_path), env=env)
+
+    assert result.returncode == 1
+    assert "no android device matches 'nope'" in result.stdout
+
+
 def test_hot_reload_manifest_payload_maps_files_to_modules(tmp_path: Path) -> None:
     app_dir = tmp_path / "app"
     app_dir.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -636,7 +636,10 @@ def test_logs_command_android_sets_android_serial_for_device(
 
     pn_cli.logs_command(argparse.Namespace(platform="android", device="Pixel"))
 
-    assert os.environ["ANDROID_SERIAL"] == "R5CT12345XYZ"
+    # pop() rather than a plain lookup: monkeypatch.delenv() on a variable that
+    # was never set has nothing to restore, so the value the command exported
+    # would otherwise leak into the rest of the session.
+    assert os.environ.pop("ANDROID_SERIAL") == "R5CT12345XYZ"
 
 
 def test_logs_command_android_no_device_leaves_android_serial_unset(
@@ -651,7 +654,7 @@ def test_logs_command_android_no_device_leaves_android_serial_unset(
     assert "ANDROID_SERIAL" not in os.environ
 
 
-def test_logs_command_ios_passes_resolved_udid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_logs_command_ios_passes_resolved_udid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
     monkeypatch.setattr(
         pn_cli, "_load_config_or_exit", lambda project_dir=None: argparse.Namespace(bundle_id="com.example.app")
@@ -698,6 +701,24 @@ def test_logs_command_ios_physical_device_prints_console_hint(
 
     with pytest.raises(SystemExit) as exc_info:
         pn_cli.logs_command(argparse.Namespace(platform="ios", device="Owen's iPhone"))
+
+    assert exc_info.value.code == 1
+    assert "Console.app" in capsys.readouterr().out
+
+
+def test_logs_command_ios_no_simulator_prints_console_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Without --device and with no booted simulator, the user may well be
+    # holding a physical device, so the Console.app pointer must still print.
+    monkeypatch.setattr(pn_cli.devices_mod, "list_devices", _fake_list_devices(_FAKE_DEVICES))
+    monkeypatch.setattr(
+        pn_cli, "_load_config_or_exit", lambda project_dir=None: argparse.Namespace(bundle_id="com.example.app")
+    )
+    monkeypatch.setattr(pn_cli, "_start_ios_log_stream", lambda bundle_id, *, udid=None: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        pn_cli.logs_command(argparse.Namespace(platform="ios", device=None))
 
     assert exc_info.value.code == 1
     assert "Console.app" in capsys.readouterr().out


### PR DESCRIPTION
- Add --device/-d to the logs subparser, resolving the same way pn run does via _resolve_device.
- Android: set ANDROID_SERIAL from the resolved device so adb/logcat target it for the whole stream.
- iOS: thread the resolved UDID into _start_ios_log_stream instead of always falling back to the booted simulator. Physical iOS devices print the existing Console.app guidance and exit, matching how pn logs already behaves without --device.
- Add CLI tests covering the Android ANDROID_SERIAL path, the iOS UDID threading (both resolved and no-device/booted-fallback cases), the physical-device rejection, a bad --device query, and that --device is actually wired through argparse.
- Document the new flag in docs/api/cli.md.

Fixes #38