### PR TITLE
docs(mkdocs): add preview API reference page

### DIFF
--- a/docs/api/preview.md
+++ b/docs/api/preview.md
@@ -1,0 +1,19 @@
+# Preview
+
+The desktop preview is the engine behind `pn preview`: it renders an
+app in a real OS window through the Tkinter backend, with Fast
+Refresh on every save. [`run_preview`][pythonnative.preview.run_preview]
+opens the window and runs until it closes, and
+[`DesktopApp`][pythonnative.preview.DesktopApp] owns the navigation
+stack inside it.
+
+::: pythonnative.preview
+    options:
+        show_root_heading: false
+        show_root_toc_entry: false
+        members_order: source
+        filters: ["!^_"]
+
+## Next steps
+
+- See the workflow in the [Desktop preview guide](../guides/desktop-preview.md).

--- a/docs/guides/desktop-preview.md
+++ b/docs/guides/desktop-preview.md
@@ -62,7 +62,7 @@ No other dependencies are required; the desktop backend is pure Python.
 ## How it works
 
 `pn preview` sets `PN_PLATFORM=desktop` and starts
-`pythonnative.preview.run_preview`, which:
+[`run_preview`](../api/preview.md), which:
 
 1. Opens a single Tk window with one *stage* frame.
 2. Selects the Tkinter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - Platform metrics: api/platform_metrics.md
     - SDK: api/sdk.md
     - Hot reload: api/hot_reload.md
+    - Preview: api/preview.md
     - Diagnostics: api/diagnostics.md
     - Utilities: api/utils.md
     - CLI (pn): api/cli.md

--- a/src/pythonnative/preview.py
+++ b/src/pythonnative/preview.py
@@ -1,7 +1,7 @@
 """Desktop preview runtime, the engine behind ``pn preview``.
 
 ``pn preview`` renders a PythonNative app in a real OS window using the
-Tkinter backend (``pythonnative.native_views.desktop``),
+Tkinter backend ([`pythonnative.native_views.desktop`][pythonnative.native_views.desktop]),
 with **instant Fast Refresh** on every file save. It exists to make the
 inner development loop fast: see your UI and iterate in seconds without
 booting a simulator or deploying to a device.
@@ -12,7 +12,7 @@ Architecture
   navigation stack gets its own child container inside the stage; the
   desktop view handlers create widgets under the active container.
 - [`DesktopApp`][pythonnative.preview.DesktopApp] owns the navigation
-  stack of ``pythonnative.screen`` hosts and the push/pop/reset
+  stack of [`screen`][pythonnative.screen] hosts and the push/pop/reset
   primitives the declarative navigators call through ``host._push`` /
   ``host._pop``.
 - The Tk event loop runs on the main thread. A lightweight poll
@@ -77,7 +77,7 @@ class DesktopApp:
     """Navigation-stack controller for the desktop preview window.
 
     One instance backs a preview session. It is handed to each
-    ``pythonnative.screen`` host as the ``native_instance`` so
+    [`screen`][pythonnative.screen] host as the ``native_instance`` so
     hosts can drive navigation (``push_screen`` / ``pop_screen`` /
     ``reset_to_root``), report the viewport size, and set the window
     title, mirroring the role a ``UIViewController`` / ``Activity``

--- a/src/pythonnative/preview.py
+++ b/src/pythonnative/preview.py
@@ -1,7 +1,7 @@
 """Desktop preview runtime, the engine behind ``pn preview``.
 
 ``pn preview`` renders a PythonNative app in a real OS window using the
-Tkinter backend ([`pythonnative.native_views.desktop`][pythonnative.native_views.desktop]),
+Tkinter backend (``pythonnative.native_views.desktop``),
 with **instant Fast Refresh** on every file save. It exists to make the
 inner development loop fast: see your UI and iterate in seconds without
 booting a simulator or deploying to a device.
@@ -12,7 +12,7 @@ Architecture
   navigation stack gets its own child container inside the stage; the
   desktop view handlers create widgets under the active container.
 - [`DesktopApp`][pythonnative.preview.DesktopApp] owns the navigation
-  stack of [`screen`][pythonnative.screen] hosts and the push/pop/reset
+  stack of ``pythonnative.screen`` hosts and the push/pop/reset
   primitives the declarative navigators call through ``host._push`` /
   ``host._pop``.
 - The Tk event loop runs on the main thread. A lightweight poll
@@ -77,7 +77,7 @@ class DesktopApp:
     """Navigation-stack controller for the desktop preview window.
 
     One instance backs a preview session. It is handed to each
-    [`screen`][pythonnative.screen] host as the ``native_instance`` so
+    ``pythonnative.screen`` host as the ``native_instance`` so
     hosts can drive navigation (``push_screen`` / ``pop_screen`` /
     ``reset_to_root``), report the viewport size, and set the window
     title, mirroring the role a ``UIViewController`` / ``Activity``

--- a/src/pythonnative/preview.py
+++ b/src/pythonnative/preview.py
@@ -1,7 +1,7 @@
 """Desktop preview runtime, the engine behind ``pn preview``.
 
 ``pn preview`` renders a PythonNative app in a real OS window using the
-Tkinter backend ([`pythonnative.native_views.desktop`][pythonnative.native_views.desktop]),
+Tkinter backend (``pythonnative.native_views.desktop``),
 with **instant Fast Refresh** on every file save. It exists to make the
 inner development loop fast: see your UI and iterate in seconds without
 booting a simulator or deploying to a device.
@@ -12,7 +12,7 @@ Architecture
   navigation stack gets its own child container inside the stage; the
   desktop view handlers create widgets under the active container.
 - [`DesktopApp`][pythonnative.preview.DesktopApp] owns the navigation
-  stack of [`screen`][pythonnative.screen] hosts and the push/pop/reset
+  stack of ``pythonnative.screen`` hosts and the push/pop/reset
   primitives the declarative navigators call through ``host._push`` /
   ``host._pop``.
 - The Tk event loop runs on the main thread. A lightweight poll
@@ -77,7 +77,7 @@ class DesktopApp:
     """Navigation-stack controller for the desktop preview window.
 
     One instance backs a preview session. It is handed to each
-    [`screen`][pythonnative.screen] host as the ``native_instance`` so
+    [``create_screen``][pythonnative.create_screen] host as the ``native_instance`` so
     hosts can drive navigation (``push_screen`` / ``pop_screen`` /
     ``reset_to_root``), report the viewport size, and set the window
     title, mirroring the role a ``UIViewController`` / ``Activity``


### PR DESCRIPTION
## What
Add an API reference page for `pythonnative.preview` and link it from the docs.

## Changes
New `docs/api/preview.md` using the standard thin mkdocstrings pattern (intro + ::: pythonnative.preview), nav entry in `mkdocs.yml`, and a cross-link from the desktop preview guide. 

Two docstring cross-references in `preview.py` were switched to plain code spans because their targets (`pythonnative.screen, pythonnative.native_views.desktop`) have no rendered anchors, which `mkdocs build --strict` flags.


Closes #41 