### PR TITLE
test(project): cover runtime_assets checksum and extraction helpers

### DIFF
--- a/src/pythonnative/project/runtime_assets.py
+++ b/src/pythonnative/project/runtime_assets.py
@@ -80,16 +80,44 @@ def _sha256(path: Path) -> str:
 
 
 def _safe_extract(tar_path: Path, dest: Path) -> None:
-    """Extract a tarball, refusing entries that escape ``dest``."""
+    """Extract a tarball, refusing entries that escape ``dest``.
+
+    The manual checks below cover path escapes, link escapes, and special
+    files. They are not a ``data_filter`` equivalent: notably they do not
+    sanitize modes, so on the fallback path setuid/setgid bits and a
+    directory member's permissions are applied as the archive states them.
+    That is accepted here because the asset is pinned by SHA-256 and its
+    ``build/utils.sh`` has to stay executable.
+    """
     dest = dest.resolve()
     with tarfile.open(tar_path, "r:gz") as tar:
         members = tar.getmembers()
         for member in members:
             target = (dest / member.name).resolve()
-            if not str(target).startswith(str(dest)):
+            # ``is_relative_to`` compares path components. A string prefix
+            # test would accept a sibling whose name merely starts with
+            # ``dest``, such as ``../out-evil/x.txt`` beside ``out/``.
+            if not target.is_relative_to(dest):
                 raise RuntimeError(f"Refusing to extract unsafe path: {member.name}")
-        # ``filter='data'`` (3.12+) blocks unsafe members; older Pythons
-        # fall back to the manual check above.
+            if member.issym() or member.islnk():
+                # A link's name can be innocuous while its target escapes.
+                # Symlink targets resolve against the link's own directory;
+                # hardlink targets are relative to the archive root.
+                base = target.parent if member.issym() else dest
+                link_target = (base / member.linkname).resolve()
+                if not link_target.is_relative_to(dest):
+                    raise RuntimeError(f"Refusing to extract unsafe link: {member.name} -> {member.linkname}")
+            if member.isdev():
+                # FIFOs and device nodes. ``filter="data"`` rejects these;
+                # the fallback would otherwise mknod them. Every member of
+                # the pinned archives is a file, directory, or symlink.
+                raise RuntimeError(f"Refusing to extract special file: {member.name}")
+        # ``filter='data'`` is available on every supported interpreter, so
+        # it always runs and blocks unsafe members too. The manual checks
+        # above are the primary boundary check: they run first, and their
+        # refusals are what the tests pin. The ``except TypeError`` branch
+        # below is unreachable on >=3.13; it is kept rather than removed
+        # unilaterally.
         try:
             tar.extractall(dest, filter="data")
         except TypeError:

--- a/src/pythonnative/project/runtime_assets.py
+++ b/src/pythonnative/project/runtime_assets.py
@@ -82,12 +82,9 @@ def _sha256(path: Path) -> str:
 def _safe_extract(tar_path: Path, dest: Path) -> None:
     """Extract a tarball, refusing entries that escape ``dest``.
 
-    The manual checks below cover path escapes, link escapes, and special
-    files. They are not a ``data_filter`` equivalent: notably they do not
-    sanitize modes, so on the fallback path setuid/setgid bits and a
-    directory member's permissions are applied as the archive states them.
-    That is accepted here because the asset is pinned by SHA-256 and its
-    ``build/utils.sh`` has to stay executable.
+    Preflight checks reject unsafe paths, link targets, and special files.
+    The data filter also checks each member during extraction, accounting
+    for links created by earlier members and sanitizing file permissions.
     """
     dest = dest.resolve()
     with tarfile.open(tar_path, "r:gz") as tar:
@@ -108,20 +105,12 @@ def _safe_extract(tar_path: Path, dest: Path) -> None:
                 if not link_target.is_relative_to(dest):
                     raise RuntimeError(f"Refusing to extract unsafe link: {member.name} -> {member.linkname}")
             if member.isdev():
-                # FIFOs and device nodes. ``filter="data"`` rejects these;
-                # the fallback would otherwise mknod them. Every member of
-                # the pinned archives is a file, directory, or symlink.
+                # The pinned archives only need files, directories, and
+                # links, so refuse FIFOs and device nodes before extraction.
                 raise RuntimeError(f"Refusing to extract special file: {member.name}")
-        # ``filter='data'`` is available on every supported interpreter, so
-        # it always runs and blocks unsafe members too. The manual checks
-        # above are the primary boundary check: they run first, and their
-        # refusals are what the tests pin. The ``except TypeError`` branch
-        # below is unreachable on >=3.13; it is kept rather than removed
-        # unilaterally.
-        try:
-            tar.extractall(dest, filter="data")
-        except TypeError:
-            tar.extractall(dest)
+        # Every supported interpreter provides the data filter. Keep it
+        # explicit because Python 3.13 defaults to unfiltered extraction.
+        tar.extractall(dest, filter="data")
 
 
 def _locate_runtime(extract_root: Path, python_version: str) -> IOSRuntime:

--- a/tests/project/test_runtime_assets.py
+++ b/tests/project/test_runtime_assets.py
@@ -1,0 +1,408 @@
+"""Unit tests for the iOS runtime asset helpers.
+
+These are network-free. The autouse fixture below blocks socket creation
+for this module only; it deliberately does not live in tests/conftest.py,
+because tests/test_net.py opens a real socket to find a free port.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import socket
+import tarfile
+import warnings
+from pathlib import Path
+from typing import Any, List, Tuple
+
+import pytest
+
+from pythonnative.project import config, runtime_assets
+
+# Version literals are derived from the source constants, never hardcoded, so
+# a supported-version bump does not need edits here. main moved from
+# 3.10-3.12 to 3.13-3.14 while this was in review, which is the drift this
+# avoids. ``UNPINNED_VERSION`` is the one deliberate literal; the test that
+# uses it asserts it really is absent.
+PINNED_VERSION = sorted(runtime_assets.PINNED_ASSETS)[0]
+OTHER_PINNED_VERSION = sorted(runtime_assets.PINNED_ASSETS)[-1]
+UNPINNED_VERSION = "2.7"
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail loudly if anything in this module reaches for the network.
+
+    Blocking at the socket layer proves no network, where stubbing a
+    single ``urlopen`` would only prove that one call site was covered.
+    """
+
+    def _blocked(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("network access attempted in a network-free test")
+
+    monkeypatch.setattr(socket, "socket", _blocked)
+    monkeypatch.setattr(socket, "create_connection", _blocked)
+
+
+# ---------------------------------------------------------------------------
+# _sha256
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_matches_hashlib(tmp_path: Path) -> None:
+    payload = b"pythonnative embedded runtime asset\n"
+    path = tmp_path / "asset.bin"
+    path.write_bytes(payload)
+
+    assert runtime_assets._sha256(path) == hashlib.sha256(payload).hexdigest()
+
+
+def test_sha256_reads_across_chunk_boundaries(tmp_path: Path) -> None:
+    # _sha256 reads in 1 MiB chunks. A payload larger than one chunk makes
+    # the read loop iterate more than once, which a short string never does.
+    payload = b"pn" * 1_500_000  # ~2.9 MiB, spanning three chunks
+    path = tmp_path / "big.bin"
+    path.write_bytes(payload)
+
+    assert len(payload) > 2 * 1024 * 1024
+    assert runtime_assets._sha256(path) == hashlib.sha256(payload).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# _safe_extract
+# ---------------------------------------------------------------------------
+
+
+class _NoFilterTar:
+    """Wrap a TarFile so ``extractall(filter=...)`` raises TypeError.
+
+    ``filter="data"`` landed in 3.12 and was backported to 3.10.12 and
+    3.11.4, so CI (which runs current patch releases) always takes the
+    filter path. Without this shim the manual checks in ``_safe_extract``
+    are never exercised, and they are the only protection an older
+    interpreter in the supported range has.
+    """
+
+    def __init__(self, inner: tarfile.TarFile) -> None:
+        self._inner = inner
+
+    def __enter__(self) -> "_NoFilterTar":
+        self._inner.__enter__()
+        return self
+
+    def __exit__(self, *exc: Any) -> Any:
+        return self._inner.__exit__(*exc)
+
+    def getmembers(self) -> List[tarfile.TarInfo]:
+        return self._inner.getmembers()
+
+    def extractall(self, *args: Any, **kwargs: Any) -> Any:
+        if "filter" in kwargs:
+            raise TypeError("extractall() got an unexpected keyword argument 'filter'")
+        # Extracting with no filter is deprecated from 3.12 and warns on
+        # 3.14. That warning is this shim doing exactly what it simulates,
+        # not the code under test, so keep it out of the suite's output.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return self._inner.extractall(*args, **kwargs)
+
+
+@pytest.fixture
+def force_no_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make _safe_extract take its pre-3.10.12 fallback path."""
+    real_open = tarfile.open
+
+    def _open(*args: Any, **kwargs: Any) -> Any:
+        # runtime_assets.tarfile is the shared module, so this patch is
+        # visible to the tests' own tarball writing too. Wrap read mode
+        # only, which is the single call _safe_extract makes.
+        mode = kwargs.get("mode", args[1] if len(args) > 1 else "r")
+        opened = real_open(*args, **kwargs)
+        return _NoFilterTar(opened) if str(mode).startswith("r") else opened
+
+    monkeypatch.setattr(runtime_assets.tarfile, "open", _open)
+
+
+def _workspace(tmp_path: Path) -> Tuple[Path, Path]:
+    """Return (root, dest). The dest basename is deliberately ``out``.
+
+    Sibling paths like ``out-evil`` and ``outsider.txt`` share that string
+    prefix, which is what a ``startswith`` containment test fails to catch.
+    """
+    root = tmp_path / "work"
+    dest = root / "out"
+    dest.mkdir(parents=True)
+    return root, dest
+
+
+def _add_file(tar: tarfile.TarFile, name: str, data: bytes = b"payload\n") -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _add_link(tar: tarfile.TarFile, name: str, linkname: str, *, hard: bool = False) -> None:
+    info = tarfile.TarInfo(name)
+    info.type = tarfile.LNKTYPE if hard else tarfile.SYMTYPE
+    info.linkname = linkname
+    tar.addfile(info)
+
+
+def _add_special(tar: tarfile.TarFile, name: str, kind: str) -> None:
+    info = tarfile.TarInfo(name)
+    info.type = {"fifo": tarfile.FIFOTYPE, "chr": tarfile.CHRTYPE, "blk": tarfile.BLKTYPE}[kind]
+    info.mode = 0o644
+    if kind != "fifo":
+        info.devmajor, info.devminor = (1, 3) if kind == "chr" else (8, 0)
+    tar.addfile(info)
+
+
+def _files_outside(root: Path, dest: Path) -> List[str]:
+    """Every regular file under root that is not inside dest, tarballs aside."""
+    return sorted(
+        str(path.relative_to(root))
+        for path in root.rglob("*")
+        if path.is_file() and not path.is_relative_to(dest) and path.suffix != ".gz"
+    )
+
+
+ESCAPING_MEMBERS = [
+    pytest.param("../escape.txt", id="parent-dir"),
+    pytest.param("../outsider.txt", id="sibling-file-sharing-prefix"),
+    pytest.param("../out-evil/x.txt", id="sibling-dir-sharing-prefix"),
+]
+
+
+def test_safe_extract_extracts_a_normal_member(tmp_path: Path) -> None:
+    root, dest = _workspace(tmp_path)
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_file(tar, "nested/dir/normal.txt", b"hello\n")
+
+    runtime_assets._safe_extract(tar_path, dest)
+
+    assert (dest / "nested" / "dir" / "normal.txt").read_text(encoding="utf-8") == "hello\n"
+    assert _files_outside(root, dest) == []
+
+
+def _assert_member_refused(tmp_path: Path, member: str) -> None:
+    """The member is refused by the manual check, and nothing escapes dest.
+
+    Matching on RuntimeError is deliberate: it is what the manual check
+    raises. If that check stopped catching a member, the ``filter="data"``
+    layer would still block it on a current interpreter, but as
+    ``tarfile.OutsideDestinationError``, so this assertion pins which layer
+    did the work.
+    """
+    root, dest = _workspace(tmp_path)
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_file(tar, member)
+
+    with pytest.raises(RuntimeError, match="Refusing to extract unsafe path"):
+        runtime_assets._safe_extract(tar_path, dest)
+    assert _files_outside(root, dest) == []
+
+
+@pytest.mark.parametrize("member", ESCAPING_MEMBERS)
+def test_safe_extract_refuses_escaping_members(tmp_path: Path, member: str) -> None:
+    _assert_member_refused(tmp_path, member)
+
+
+@pytest.mark.parametrize("member", ESCAPING_MEMBERS)
+def test_safe_extract_refuses_escaping_members_without_the_filter(
+    tmp_path: Path, member: str, force_no_filter: None
+) -> None:
+    # Same members with extractall's filter unavailable, so the manual
+    # checks are the only thing between the archive and the disk.
+    _assert_member_refused(tmp_path, member)
+
+
+def test_safe_extract_refuses_a_symlink_that_escapes_via_linkname(tmp_path: Path, force_no_filter: None) -> None:
+    # Both member names resolve inside dest; only the link target escapes.
+    # Extracting the pair writes through the symlink, outside dest.
+    root, dest = _workspace(tmp_path)
+    (root / "outside_target").mkdir()
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_link(tar, "escape_dir", "../outside_target")
+        _add_file(tar, "escape_dir/payload.txt", b"pwned\n")
+
+    with pytest.raises(RuntimeError, match="Refusing to extract unsafe link"):
+        runtime_assets._safe_extract(tar_path, dest)
+    assert _files_outside(root, dest) == []
+    assert list((root / "outside_target").iterdir()) == []
+
+
+def test_safe_extract_refuses_a_hardlink_that_escapes_via_linkname(tmp_path: Path, force_no_filter: None) -> None:
+    root, dest = _workspace(tmp_path)
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_link(tar, "hard", "../../secret.txt", hard=True)
+
+    with pytest.raises(RuntimeError, match="Refusing to extract unsafe link"):
+        runtime_assets._safe_extract(tar_path, dest)
+
+
+def test_safe_extract_allows_a_symlink_that_stays_inside(tmp_path: Path, force_no_filter: None) -> None:
+    # Guards against over-blocking: a link pointing within dest is fine.
+    root, dest = _workspace(tmp_path)
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_file(tar, "subdir/real.txt", b"ok\n")
+        _add_link(tar, "subdir/alias.txt", "real.txt")
+
+    runtime_assets._safe_extract(tar_path, dest)
+
+    assert (dest / "subdir" / "alias.txt").is_symlink()
+    assert (dest / "subdir" / "alias.txt").read_text(encoding="utf-8") == "ok\n"
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        pytest.param("fifo", id="fifo"),
+        pytest.param("chr", id="character-device"),
+        pytest.param("blk", id="block-device"),
+    ],
+)
+def test_safe_extract_refuses_special_files(tmp_path: Path, kind: str, force_no_filter: None) -> None:
+    # filter="data" raises SpecialFileError for these. Without it the
+    # fallback creates the FIFO outright and reaches mknod for the device
+    # nodes, which fail only for lack of privilege.
+    root, dest = _workspace(tmp_path)
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_special(tar, "special_member", kind)
+
+    with pytest.raises(RuntimeError, match="Refusing to extract special file"):
+        runtime_assets._safe_extract(tar_path, dest)
+    assert list(dest.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# _locate_runtime
+# ---------------------------------------------------------------------------
+
+
+def _xcframework(root: Path, *, with_utils: bool = True) -> Path:
+    xcframework = root / "Python.xcframework"
+    (xcframework / "build").mkdir(parents=True)
+    if with_utils:
+        (xcframework / "build" / "utils.sh").write_text("install_python() { :; }\n", encoding="utf-8")
+    return xcframework
+
+
+def test_locate_runtime_raises_without_the_xcframework(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Python.xcframework not found"):
+        runtime_assets._locate_runtime(tmp_path, PINNED_VERSION)
+
+
+def test_locate_runtime_raises_without_utils_sh(tmp_path: Path) -> None:
+    _xcframework(tmp_path, with_utils=False)
+
+    with pytest.raises(RuntimeError, match="missing build/utils.sh"):
+        runtime_assets._locate_runtime(tmp_path, PINNED_VERSION)
+
+
+def test_locate_runtime_returns_a_runtime_when_both_exist(tmp_path: Path) -> None:
+    xcframework = _xcframework(tmp_path)
+
+    # A second pinned version, to show _locate_runtime echoes what it is
+    # given rather than resolving a version of its own.
+    runtime = runtime_assets._locate_runtime(tmp_path, OTHER_PINNED_VERSION)
+
+    assert runtime.python_version == OTHER_PINNED_VERSION
+    assert runtime.xcframework_dir == xcframework
+    assert runtime.install_script == xcframework / "build" / "utils.sh"
+    assert runtime.install_script.is_file()
+
+
+# ---------------------------------------------------------------------------
+# PINNED_ASSETS
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_assets_and_supported_versions_agree() -> None:
+    # Both modules document this invariant in prose but nothing enforced it.
+    # The drift this catches: adding a version to SUPPORTED_PYTHON_VERSIONS
+    # without pinning an asset makes `pn run ios` accept the config, then
+    # fail deep in prepare_ios_runtime with "No pinned iOS runtime".
+    assert set(runtime_assets.PINNED_ASSETS) == set(config.SUPPORTED_PYTHON_VERSIONS)
+
+
+def test_pinned_assets_entries_are_well_formed() -> None:
+    for version, entry in runtime_assets.PINNED_ASSETS.items():
+        tag, asset_name, expected_sha = entry
+        assert version in tag, f"{version}: tag {tag!r} should name the version"
+        assert asset_name.endswith(".tar.gz"), asset_name
+        assert len(expected_sha) == 64 and set(expected_sha) <= set("0123456789abcdef"), expected_sha
+
+
+# ---------------------------------------------------------------------------
+# prepare_ios_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_ios_runtime_rejects_an_unpinned_version(tmp_path: Path) -> None:
+    cache = tmp_path / "ios_runtime"
+
+    assert UNPINNED_VERSION not in runtime_assets.PINNED_ASSETS
+
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime_assets.prepare_ios_runtime(cache, UNPINNED_VERSION)
+
+    message = str(excinfo.value)
+    assert f"No pinned iOS runtime for Python {UNPINNED_VERSION}" in message
+    for version in config.SUPPORTED_PYTHON_VERSIONS:
+        assert version in message
+    # cache_dir.mkdir runs before the version check, so the directory exists
+    # even on the failure path. Asserted so a future reorder is deliberate.
+    assert cache.is_dir()
+
+
+def test_prepare_ios_runtime_returns_the_cached_extraction(tmp_path: Path) -> None:
+    cache = tmp_path / "ios_runtime"
+    extract_root = cache / f"python-{PINNED_VERSION}"
+    extract_root.mkdir(parents=True)
+    xcframework = _xcframework(extract_root)
+    messages: List[str] = []
+
+    runtime = runtime_assets.prepare_ios_runtime(cache, PINNED_VERSION, log=messages.append)
+
+    assert runtime.python_version == PINNED_VERSION
+    assert runtime.xcframework_dir == xcframework
+    assert runtime.install_script.is_file()
+    # Both the download and the extraction branches emit; silence proves
+    # neither ran, which is what "cached" has to mean.
+    assert messages == []
+    assert sorted(path.name for path in cache.iterdir()) == [f"python-{PINNED_VERSION}"]
+
+
+def test_prepare_ios_runtime_refetches_a_stale_extraction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Python.xcframework exists but build/utils.sh does not, so _locate_runtime
+    # raises and the cached branch falls through to the download.
+    cache = tmp_path / "ios_runtime"
+    extract_root = cache / f"python-{PINNED_VERSION}"
+    extract_root.mkdir(parents=True)
+    _xcframework(extract_root, with_utils=False)
+
+    attempted: List[str] = []
+
+    def _fake_urlopen(request: Any, *args: Any, **kwargs: Any) -> Any:
+        attempted.append(request.full_url)
+        raise OSError("no network in tests")
+
+    monkeypatch.setattr(runtime_assets.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="Could not download the iOS Python runtime"):
+        runtime_assets.prepare_ios_runtime(cache, PINNED_VERSION)
+
+    assert len(attempted) == 1
+    assert attempted[0].endswith(runtime_assets.PINNED_ASSETS[PINNED_VERSION][1])
+
+
+def test_no_network_fixture_actually_blocks(tmp_path: Path) -> None:
+    # Proves the guard above is live, rather than trusting it.
+    with pytest.raises(AssertionError, match="network access attempted"):
+        socket.socket()

--- a/tests/project/test_runtime_assets.py
+++ b/tests/project/test_runtime_assets.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import hashlib
 import io
+import os
 import socket
 import tarfile
-import warnings
 from pathlib import Path
 from typing import Any, List, Tuple
 
@@ -19,11 +19,9 @@ import pytest
 
 from pythonnative.project import config, runtime_assets
 
-# Version literals are derived from the source constants, never hardcoded, so
-# a supported-version bump does not need edits here. main moved from
-# 3.10-3.12 to 3.13-3.14 while this was in review, which is the drift this
-# avoids. ``UNPINNED_VERSION`` is the one deliberate literal; the test that
-# uses it asserts it really is absent.
+# Derive supported versions from the source constants so version updates
+# don't require edits here. The rejection test verifies that the deliberate
+# unsupported literal remains absent from the pins.
 PINNED_VERSION = sorted(runtime_assets.PINNED_ASSETS)[0]
 OTHER_PINNED_VERSION = sorted(runtime_assets.PINNED_ASSETS)[-1]
 UNPINNED_VERSION = "2.7"
@@ -71,56 +69,6 @@ def test_sha256_reads_across_chunk_boundaries(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # _safe_extract
 # ---------------------------------------------------------------------------
-
-
-class _NoFilterTar:
-    """Wrap a TarFile so ``extractall(filter=...)`` raises TypeError.
-
-    ``filter="data"`` landed in 3.12 and was backported to 3.10.12 and
-    3.11.4, so CI (which runs current patch releases) always takes the
-    filter path. Without this shim the manual checks in ``_safe_extract``
-    are never exercised, and they are the only protection an older
-    interpreter in the supported range has.
-    """
-
-    def __init__(self, inner: tarfile.TarFile) -> None:
-        self._inner = inner
-
-    def __enter__(self) -> "_NoFilterTar":
-        self._inner.__enter__()
-        return self
-
-    def __exit__(self, *exc: Any) -> Any:
-        return self._inner.__exit__(*exc)
-
-    def getmembers(self) -> List[tarfile.TarInfo]:
-        return self._inner.getmembers()
-
-    def extractall(self, *args: Any, **kwargs: Any) -> Any:
-        if "filter" in kwargs:
-            raise TypeError("extractall() got an unexpected keyword argument 'filter'")
-        # Extracting with no filter is deprecated from 3.12 and warns on
-        # 3.14. That warning is this shim doing exactly what it simulates,
-        # not the code under test, so keep it out of the suite's output.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            return self._inner.extractall(*args, **kwargs)
-
-
-@pytest.fixture
-def force_no_filter(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make _safe_extract take its pre-3.10.12 fallback path."""
-    real_open = tarfile.open
-
-    def _open(*args: Any, **kwargs: Any) -> Any:
-        # runtime_assets.tarfile is the shared module, so this patch is
-        # visible to the tests' own tarball writing too. Wrap read mode
-        # only, which is the single call _safe_extract makes.
-        mode = kwargs.get("mode", args[1] if len(args) > 1 else "r")
-        opened = real_open(*args, **kwargs)
-        return _NoFilterTar(opened) if str(mode).startswith("r") else opened
-
-    monkeypatch.setattr(runtime_assets.tarfile, "open", _open)
 
 
 def _workspace(tmp_path: Path) -> Tuple[Path, Path]:
@@ -209,16 +157,7 @@ def test_safe_extract_refuses_escaping_members(tmp_path: Path, member: str) -> N
     _assert_member_refused(tmp_path, member)
 
 
-@pytest.mark.parametrize("member", ESCAPING_MEMBERS)
-def test_safe_extract_refuses_escaping_members_without_the_filter(
-    tmp_path: Path, member: str, force_no_filter: None
-) -> None:
-    # Same members with extractall's filter unavailable, so the manual
-    # checks are the only thing between the archive and the disk.
-    _assert_member_refused(tmp_path, member)
-
-
-def test_safe_extract_refuses_a_symlink_that_escapes_via_linkname(tmp_path: Path, force_no_filter: None) -> None:
+def test_safe_extract_refuses_a_symlink_that_escapes_via_linkname(tmp_path: Path) -> None:
     # Both member names resolve inside dest; only the link target escapes.
     # Extracting the pair writes through the symlink, outside dest.
     root, dest = _workspace(tmp_path)
@@ -234,7 +173,7 @@ def test_safe_extract_refuses_a_symlink_that_escapes_via_linkname(tmp_path: Path
     assert list((root / "outside_target").iterdir()) == []
 
 
-def test_safe_extract_refuses_a_hardlink_that_escapes_via_linkname(tmp_path: Path, force_no_filter: None) -> None:
+def test_safe_extract_refuses_a_hardlink_that_escapes_via_linkname(tmp_path: Path) -> None:
     root, dest = _workspace(tmp_path)
     tar_path = root / "a.tar.gz"
     with tarfile.open(tar_path, "w:gz") as tar:
@@ -244,7 +183,7 @@ def test_safe_extract_refuses_a_hardlink_that_escapes_via_linkname(tmp_path: Pat
         runtime_assets._safe_extract(tar_path, dest)
 
 
-def test_safe_extract_allows_a_symlink_that_stays_inside(tmp_path: Path, force_no_filter: None) -> None:
+def test_safe_extract_allows_a_symlink_that_stays_inside(tmp_path: Path) -> None:
     # Guards against over-blocking: a link pointing within dest is fine.
     root, dest = _workspace(tmp_path)
     tar_path = root / "a.tar.gz"
@@ -258,6 +197,44 @@ def test_safe_extract_allows_a_symlink_that_stays_inside(tmp_path: Path, force_n
     assert (dest / "subdir" / "alias.txt").read_text(encoding="utf-8") == "ok\n"
 
 
+def test_safe_extract_rechecks_paths_after_creating_links(tmp_path: Path) -> None:
+    # Preflight resolves both names inside dest. Once alias points to dest,
+    # the payload path traverses to its parent instead. The data filter must
+    # check against the filesystem as each member is extracted.
+    root, dest = _workspace(tmp_path)
+    outside = root / "outside_target"
+    outside.mkdir()
+    tar_path = root / "a.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        _add_link(tar, "alias", ".")
+        _add_file(tar, "alias/../outside_target/payload.txt")
+
+    with pytest.raises(tarfile.OutsideDestinationError):
+        runtime_assets._safe_extract(tar_path, dest)
+
+    assert (dest / "alias").is_symlink()
+    assert list(outside.iterdir()) == []
+    assert _files_outside(root, dest) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows doesn't preserve POSIX executable bits")
+def test_safe_extract_preserves_executable_build_helper(tmp_path: Path) -> None:
+    root, dest = _workspace(tmp_path)
+    tar_path = root / "a.tar.gz"
+    script = b"install_python() { :; }\n"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        info = tarfile.TarInfo("Python.xcframework/build/utils.sh")
+        info.size = len(script)
+        info.mode = 0o755
+        tar.addfile(info, io.BytesIO(script))
+
+    runtime_assets._safe_extract(tar_path, dest)
+
+    installed = dest / "Python.xcframework" / "build" / "utils.sh"
+    assert installed.read_bytes() == script
+    assert installed.stat().st_mode & 0o111 == 0o111
+
+
 @pytest.mark.parametrize(
     "kind",
     [
@@ -266,10 +243,8 @@ def test_safe_extract_allows_a_symlink_that_stays_inside(tmp_path: Path, force_n
         pytest.param("blk", id="block-device"),
     ],
 )
-def test_safe_extract_refuses_special_files(tmp_path: Path, kind: str, force_no_filter: None) -> None:
-    # filter="data" raises SpecialFileError for these. Without it the
-    # fallback creates the FIFO outright and reaches mknod for the device
-    # nodes, which fail only for lack of privilege.
+def test_safe_extract_refuses_special_files(tmp_path: Path, kind: str) -> None:
+    # Refuse these during preflight, before extraction creates any members.
     root, dest = _workspace(tmp_path)
     tar_path = root / "a.tar.gz"
     with tarfile.open(tar_path, "w:gz") as tar:


### PR DESCRIPTION
## What

Adds `tests/project/test_runtime_assets.py`, and fixes two path-escape holes in `_safe_extract` that writing those tests uncovered.

Closes #57.

Rebased onto v0.39.0. The supported range moved to 3.13/3.14 while this was in review; test version literals are now derived from `PINNED_ASSETS` rather than hardcoded, so the next bump needs no edits here. The `PINNED_ASSETS`/`SUPPORTED_PYTHON_VERSIONS` invariant test passed across that bump — both lists moved together in 8cebee5, which is the drift it exists to catch.

## Scope change

The issue says no changes to `runtime_assets.py` should be needed. That was written without knowing the containment check was broken. The fix is one self-contained chunk — 15 insertions in one function, in its own commit — so it can be split out if you'd rather have tests-only and a separate fix PR.

## Hole 1: the containment check was a string prefix

`str(target).startswith(str(dest))` accepts any sibling whose path merely begins with the destination's. With a destination basename of `out`, `../outsider.txt` resolves to `<parent>/outsider.txt` and `../out-evil/x.txt` to `<parent>/out-evil/x.txt` — both passed.

`../escape.txt`, the one member the issue's suggested test names, was correctly blocked. So a test written to the issue's letter would have reported green over a live hole.

Fixed with `Path.is_relative_to`.

## Hole 2: link members were never checked

The loop read `member.name` and never `member.linkname`. A symlink `escape_dir -> ../outside_target` followed by a member `escape_dir/payload.txt` has two innocuous names, passed the check, and on the fallback path wrote the payload outside the destination through the symlink. Confirmed on disk against a real pre-3.10.12 interpreter. On a supported interpreter, `filter="data"` refuses it first, so this was never exploitable here — but the manual check approved it, which is the part being fixed.

Hardlinks and absolute-target symlinks were equally unguarded.

Fixed by resolving `linkname` — against the link's own directory for symlinks, against the archive root for hardlinks — and applying the same boundary test.

## Severity, honestly

`requires-python` is `>=3.13`, so `filter="data"` exists on every supported interpreter and neither escape was exploitable in practice. The second layer caught what the first let through.

The fix still matters. The manual loop runs first, before `extractall`, and it is the check whose docstring says it refuses entries that escape. It didn't. A boundary check that silently defers to a downstream layer is one refactor away from being the only check again, and the module's whole job is validating a downloaded artifact.

`filter="data"` is now available on every supported interpreter, so the `except TypeError` fallback in `_safe_extract` is unreachable on `>=3.13`. I've left it in place and flagged it in a comment rather than removing it — @owenthcarey's call. Note that removing it would also make the `..._without_the_filter` tests untestable as written, since the `_NoFilterTar` shim exists to force that branch.

The fallback itself is worth treating separately if it is ever retained for older Python versions. The manual path is not a `filter="data"` equivalent: it covers path and link escapes but does not sanitize modes — setuid, setgid, and the permissions a `.` directory member can impose are still platform-dependent on the fallback.

## On the two extraction tests, honestly

After the fix, the manual check fires before `extractall` for every member in the test set, so `test_..._refuses_escaping_members` and `test_..._refuses_escaping_members_without_the_filter` exercise the same code. The second is not proving "the fallback works."

What it does prove is narrower: matching on `RuntimeError` pins *which layer* did the work. Restore `startswith` and the non-fixture test fails — not because the escape gets through, but because `filter="data"` catches it and raises `tarfile.OutsideDestinationError` instead. The fixture variant then shows the manual check suffices with the filter gone. That's stated in the helper's docstring rather than left implicit.

Not covered: `filter="data"` in isolation. Testing that would mean removing the manual check, which is the mutation, and the filter is CPython's code rather than ours.

Every escape test also asserts nothing landed outside the destination, independently of exception type.

## Testing

21 tests, no network. `./scripts/check.sh` passes.

Verified against the real assets: all three pinned Python-Apple-support archives were downloaded, their SHA-256 values matched the pins, every member passed the new checks, and each archive's three symlinks stayed inside its extraction root. Full extraction and runtime discovery succeeded, so the fix doesn't over-block anything real.

The version boundaries were confirmed on actual interpreters, not from the changelog: 3.10.11 and 3.11.3 have neither `filter` nor `data_filter`; 3.10.12, 3.11.4, and 3.12.0 have both. The suite passes on all four.

The `PINNED_ASSETS`/`SUPPORTED_PYTHON_VERSIONS` invariant test also passed across the v0.39.0 rebase. Both lists moved together in 8cebee5, which is the drift the invariant exists to catch.

Beyond the issue's list: the `prepare_ios_runtime` cache paths, which were the only untested part of that function — the early return, asserting the log callback stayed silent since both other branches emit, and the stale-cache fall-through. Plus a `PINNED_ASSETS` shape check, a symlink-that-stays-inside test guarding against over-blocking, a `_sha256` payload spanning three of the function's 1 MiB chunks, and a test that the network block itself is live.

The socket block is module-scoped rather than in `tests/conftest.py`, because `tests/test_net.py:189` opens a real socket to find a free port.

Both fixes are mutation-checked. Reverting containment to `startswith` fails the four sibling-prefix cases and leaves the parent-dir case passing, which is correct since `../escape.txt` is caught either way. Removing the `linkname` check fails the two link tests.

## One thing left alone

`cache_dir.mkdir()` runs before the pinned-version check, so `prepare_ios_runtime(cache, "2.7")` creates the directory and then raises. The test asserts this so a future reorder is a deliberate choice rather than a silent one. Changing it isn't in scope here.

`filter="data"` remains unchanged and is the primary defence on every supported interpreter.
