### PR TITLE
docs(cli): add help text for positional platform arguments

### DIFF
--- a/src/pythonnative/cli/pn.py
+++ b/src/pythonnative/cli/pn.py
@@ -1113,7 +1113,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser_devices.set_defaults(func=devices_command)
 
     parser_run = subparsers.add_parser("run", help="Build, install, and launch on a device/simulator")
-    parser_run.add_argument("platform", choices=["android", "ios"])
+    parser_run.add_argument("platform", choices=["android", "ios"], help="Target platform")
     parser_run.add_argument(
         "--device",
         "-d",
@@ -1140,7 +1140,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser_run.set_defaults(func=run_project)
 
     parser_logs = subparsers.add_parser("logs", help="Stream logs from the running app")
-    parser_logs.add_argument("platform", choices=["android", "ios"])
+    parser_logs.add_argument("platform", choices=["android", "ios"], help="Target platform")
     parser_logs.add_argument(
         "--device",
         "-d",
@@ -1150,7 +1150,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser_logs.set_defaults(func=logs_command)
 
     parser_build = subparsers.add_parser("build", help="Build distributable artifacts")
-    parser_build.add_argument("platform", choices=["android", "ios"])
+    parser_build.add_argument("platform", choices=["android", "ios"], help="Target platform")
     parser_build.add_argument("--debug", action="store_true", help="Build the debug variant instead of release")
     parser_build.add_argument(
         "--upload",
@@ -1160,7 +1160,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser_build.set_defaults(func=build_project)
 
     parser_app_id = subparsers.add_parser("app-id", help="Print the resolved application/bundle id")
-    parser_app_id.add_argument("platform", choices=["android", "ios"])
+    parser_app_id.add_argument("platform", choices=["android", "ios"], help="Target platform")
     parser_app_id.set_defaults(func=app_id_command)
 
     parser_clean = subparsers.add_parser("clean", help="Remove the local build/ directory")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -330,6 +330,7 @@ def test_cli_run_help_lists_flags() -> None:
         assert "--no-logs" in result.stdout
         assert "--dev-server" in result.stdout
         assert "--prepare-only" in result.stdout
+        assert "Target platform" in result.stdout
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -340,6 +341,7 @@ def test_cli_build_help_lists_debug() -> None:
         result = run_pn(["build", "--help"], tmpdir)
         assert result.returncode == 0, result.stderr
         assert "--debug" in result.stdout
+        assert "Target platform" in result.stdout
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 


### PR DESCRIPTION
What
- Add `help="Target platform"` to the required positional `platform` argument on `pn run`, `pn logs`, `pn build`, and `pn app-id`.

Why
- `pn <cmd> --help` listed `{android,ios}` under "positional arguments" with no description, while every flag on the same subcommand is described. `doctor` and `devices` already describe their `platform` argument; these four did not.

How (brief)
- One kwarg per `add_argument("platform", ...)` call in `_build_parser()` in `src/pythonnative/cli/pn.py`. Wording kept identical across the four and consistent with the existing `doctor` / `devices` strings.
- Extended the existing `--help` output tests (`test_cli_run_help_lists_flags`, `test_cli_build_help_lists_debug`) in `tests/test_cli.py` to assert the new text appears.

Testing
- ./scripts/check.sh passes.

Risks/Impact
- Help text only. No behavior change.

Docs/Follow-ups
- None.

Closes #55
