### PR TITLE
build(workflows): publish portable wheels and recover releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,62 +4,110 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to recover (leave empty for a new release)
+        type: string
+        required: false
+
+# Serialize the entire release, including manual recoveries and uploads.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   release:
-    if: github.repository == 'pythonnative/pythonnative'
-    name: Semantic Release
-    runs-on: ubuntu-latest
-    concurrency:
-      group: release
-      cancel-in-progress: false
+    if: github.repository == 'pythonnative/pythonnative' && github.ref == 'refs/heads/main'
+    name: Select release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.select.outputs.tag }}
+      commit: ${{ steps.select.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          python-version: '3.13'
+      - name: Create a version or select an existing release
+        id: select
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RECOVERY_TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "$RECOVERY_TAG" ]; then
+            # Only published release tags from main can be recovered.
+            [[ "$RECOVERY_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+            commit=$(git rev-parse --verify "refs/tags/$RECOVERY_TAG^{commit}")
+            git merge-base --is-ancestor "$commit" origin/main
+            gh release view "$RECOVERY_TAG" --json isDraft --jq '.isDraft' | grep -qx false
+            tag="$RECOVERY_TAG"
+          else
+            git config user.name "github-actions"
+            git config user.email "actions@github.com"
+            # GitPython 3.1.60 removed Actor.name_email_regex, which PSR
+            # 9.21.2 still uses. Keep this constraint until PSR is upgraded.
+            uv tool install "python-semantic-release==9.21.2" --with "gitpython<3.1.60"
+            tags_before=$(git tag | wc -l)
+            semantic-release -v version
+            tags_after=$(git tag | wc -l)
+            if [ "$tags_after" -eq "$tags_before" ]; then
+              echo "No new release. To resume an upload, run this workflow with its existing tag."
+              exit 0
+            fi
+            tag=$(git describe --tags --exact-match HEAD)
+            commit=$(git rev-parse HEAD)
+          fi
+          # Check the tag against package metadata without importing/building it.
+          git show "$commit:pyproject.toml" > "$RUNNER_TEMP/release-project.toml"
+          RELEASE_TAG="$tag" python -c 'import os, pathlib, tomllib; data = tomllib.loads((pathlib.Path(os.environ["RUNNER_TEMP"]) / "release-project.toml").read_text()); assert os.environ["RELEASE_TAG"] == "v" + data["project"]["version"]'
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+
+  distributions:
+    name: Build release distributions
+    needs: release
+    if: needs.release.outputs.tag != ''
+    uses: ./.github/workflows/wheels.yml
+    with:
+      source-ref: ${{ needs.release.outputs.commit }}
+
+  publish:
+    name: Publish distributions
+    needs: [release, distributions]
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       id-token: write
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v10.0.1
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
         with:
-          enable-cache: true
+          name: release-distributions
+          path: dist
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
           python-version: '3.13'
-
-      # TEMPORARY: inlined replacement for the
-      # python-semantic-release/python-semantic-release@v9 action. That
-      # action builds its Docker image at job time with GitPython
-      # unpinned, and GitPython 3.1.60 (2026-08-25) removed
-      # Actor.name_email_regex, which crashes every semantic-release
-      # config load (python-semantic-release issue #1475). This step
-      # mirrors the action: same git identity, same `version` command,
-      # and a `released` output for the steps below. Restore the action
-      # once the fix (python-semantic-release PR #1477) is released.
-      - name: Python Semantic Release
-        id: release
+      - name: Preserve release assets for resumable publishing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
+        run: uv run --no-project python scripts/release-assets.py "$RELEASE_TAG" dist
+      - name: Validate the exact files to publish
+        env:
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
         run: |
-          git config user.name "github-actions"
-          git config user.email "actions@github.com"
-          uv tool install "python-semantic-release==9.21.2" --with "gitpython<3.1.60"
-          tags_before=$(git tag | wc -l)
-          semantic-release -v version
-          tags_after=$(git tag | wc -l)
-          if [ "$tags_after" -gt "$tags_before" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # The distributions come from `build_command` in
-      # [tool.semantic_release], which runs `uv build` after PSR stamps the
-      # new version, so there is no separate build step here.
+          uv run --no-project --with packaging python scripts/check-distributions.py dist --version "${RELEASE_TAG#v}"
+          uvx twine check --strict dist/*
       - name: Publish to PyPI
-        if: steps.release.outputs.released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,106 @@
+name: Distributions
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      source-ref:
+        description: Commit or tag to build and test (no publishing)
+        type: string
+        required: true
+        default: main
+  workflow_call:
+    inputs:
+      source-ref:
+        description: Immutable source commit selected by the release workflow
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  sdist:
+    name: Source distribution
+    runs-on: ubuntu-24.04
+    outputs:
+      filename: ${{ steps.build.outputs.filename }}
+      version: ${{ steps.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source-ref || github.sha }}
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          python-version: '3.13'
+      - name: Build source distribution
+        id: build
+        run: |
+          uv build --sdist --python 3.13
+          echo "filename=$(basename dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+          python -c 'import tomllib; print("version=" + tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])' >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: distribution-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  wheels:
+    name: Wheels (${{ matrix.runner }})
+    needs: sdist
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-24.04, ubuntu-24.04-arm, macos-15-intel, macos-14, windows-2022]
+    steps:
+      # Build policy comes from the workflow revision, source from the sdist.
+      # Recovery uses fixed tooling with an existing tag's unmodified source.
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          name: distribution-sdist
+          path: dist
+      - name: Build, repair, install, and test wheels
+        uses: pypa/cibuildwheel@v4.2.1
+        with:
+          package-dir: dist/${{ needs.sdist.outputs.filename }}
+          config-file: ${{ github.workspace }}/scripts/cibuildwheel.toml
+          output-dir: wheelhouse
+      - uses: actions/upload-artifact@v4
+        with:
+          name: distribution-${{ matrix.runner }}
+          path: wheelhouse/*.whl
+          if-no-files-found: error
+
+  validate:
+    name: Validate release distributions
+    needs: [sdist, wheels]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: distribution-*
+          merge-multiple: true
+          path: dist
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          python-version: '3.13'
+      - name: Check metadata, platform tags, and complete wheel matrix
+        env:
+          RELEASE_VERSION: ${{ needs.sdist.outputs.version }}
+        run: |
+          uv run --no-project --with packaging python scripts/check-distributions.py dist --version "$RELEASE_VERSION"
+          uvx twine check --strict dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-distributions
+          path: dist/*
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,15 +336,47 @@ Co-authored-by: Name <email>
 
 - The version is tracked in `pyproject.toml` (`project.version`) and mirrored in `src/pythonnative/__init__.py` as `__version__`. Both files are updated automatically by [python-semantic-release](https://python-semantic-release.readthedocs.io/).
 - **Automated release pipeline** (on every merge to `main`):
-  1. `python-semantic-release` scans Conventional Commit messages since the last tag.
-  2. It determines the next SemVer bump: `feat` → **minor**, `fix`/`perf` → **patch**, `BREAKING CHANGE` → **major** (minor while version < 1.0).
-  3. Version files are updated, `CHANGELOG.md` is generated, and a tagged release commit (`chore(release): vX.Y.Z`) is pushed.
-  4. A GitHub Release is created with auto-generated release notes and the built sdist/wheel attached.
-  5. When drafts are disabled, the package is also published to PyPI via Trusted Publishing.
-- **Draft / published toggle**: the `DRAFT_RELEASE` variable at the top of `.github/workflows/release.yml` controls release mode. Set to `"true"` (the default) for draft GitHub Releases with PyPI publishing skipped; flip to `"false"` to publish releases and upload to PyPI immediately.
-- Commit types that trigger a release: `feat` (minor), `fix` and `perf` (patch), `BREAKING CHANGE` (major). All other types (`build`, `chore`, `ci`, `docs`, `refactor`, `revert`, `style`, `test`) are recorded in the changelog but do **not** trigger a release on their own.
-- Tag format: `v`-prefixed (e.g., `v0.4.0`).
-- Manual version bumps are no longer needed: just merge PRs with valid Conventional Commit titles. For ad-hoc runs, use the workflow's **Run workflow** button (`workflow_dispatch`).
+  1. `python-semantic-release` scans Conventional Commits, updates the version files and `uv.lock`, generates `CHANGELOG.md`, and pushes the release commit and tag.
+  2. A published GitHub release is created with generated release notes.
+  3. The shared `Distributions` workflow builds a source archive from that exact commit, then uses [cibuildwheel](https://cibuildwheel.pypa.io/) to build all wheels from the archive.
+  4. Each wheel is repaired where needed, installed in an isolated environment, and tested with the Yoga layout suite and CLI. The complete artifact set must also pass platform, version, resource, and metadata checks.
+  5. Validated distributions are attached to the GitHub release before PyPI uploads begin. PyPI uses Trusted Publishing; no API token is needed.
+- The same distribution builds and checks run on PRs. The wheel matrix covers CPython 3.13 and 3.14 on Linux x86-64 and ARM64 (glibc 2.28 or newer), macOS Intel and Apple Silicon (macOS 11 or newer), and Windows x64. These are development-host wheels; mobile apps compile the bundled Yoga source in their native builds.
+- Build policy lives in `scripts/cibuildwheel.toml`, separately from the tagged package source, so fixed tooling can rebuild an older release without changing its code or version. Windows compiler/linker flags also support the original `v0.40.0` source; newer source distributions include the export settings in `setup.py`.
+- Commit types that trigger a release: `feat` (minor), `fix` and `perf` (patch), and `BREAKING CHANGE` (major, or minor before 1.0). Other types, including `build` and `ci`, don't trigger a release on their own. Use a `build` or `ci` title for a publishing-only repair that should recover the existing version.
+- Tag format: `v`-prefixed (for example, `v0.40.0`). Manual version bumps aren't needed.
+
+### Recovering a failed publication
+
+Version creation and package publication are separate jobs. A GitHub release can
+exist even when its PyPI upload failed. Rerunning version creation won't create
+another release for the same commits.
+
+Once the workflow repair is merged, select **Actions → Release → Run workflow**,
+choose `main`, and enter the existing tag in the recovery field. With the GitHub
+CLI, the equivalent is:
+
+```bash
+gh workflow run release.yml --ref main -f tag=v0.40.0
+```
+
+Recovery verifies that the tag belongs to `main` and matches the package version,
+then runs the same build and validation jobs. It doesn't bump the version,
+rewrite the tag, or change the tagged source. Existing distribution assets are
+reused byte for byte; missing assets are uploaded before publishing to PyPI.
+Files already uploaded to PyPI are skipped, so a partial upload can resume.
+Release runs are serialized to prevent competing uploads.
+
+For a build-only rehearsal, run **Distributions** with a `source-ref` of the tag
+or commit to check. This runs the full matrix without publishing anything:
+
+```bash
+gh workflow run wheels.yml --ref main -f source-ref=v0.40.0
+```
+
+A source-only install of `v0.40.0` on Windows still needs the export flags from
+`scripts/cibuildwheel.toml`; its tagged `setup.py` predates that fix. The recovered
+Windows wheels include those exports and install without a compiler.
 
 ### Branch naming (suggested)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 global-exclude *.pyc *.pyo .DS_Store
+include scripts/cibuildwheel.toml scripts/check-distributions.py scripts/release-assets.py
 recursive-exclude src/pythonnative/native .build/* .gradle/* .cxx/* build/* .swiftpm/* .kotlin/*
 prune src/pythonnative/native/android/build
 prune src/pythonnative/native/android/.gradle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,11 +153,11 @@ target-version = ['py313']
 # PSR stamps the new version into pyproject.toml before running this, so
 # `--upgrade-package` re-syncs only this project's own version in the lock
 # (never dependency upgrades), and the staged uv.lock lands in the release
-# commit. This also replaces the workflow's separate `python -m build`.
+# commit. The release workflow builds distributions from that tagged commit
+# using the same cibuildwheel matrix as PR CI.
 build_command = """
 uv lock --upgrade-package pythonnative
 git add uv.lock
-uv build
 """
 version_toml = ["pyproject.toml:project.version"]
 version_variables = ["src/pythonnative/__init__.py:__version__"]

--- a/scripts/check-distributions.py
+++ b/scripts/check-distributions.py
@@ -1,0 +1,121 @@
+"""Reject incomplete or incorrectly tagged release artifacts before publishing."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import tarfile
+import tomllib
+import zipfile
+from email.parser import BytesParser
+from pathlib import Path
+
+from packaging.tags import parse_tag
+from packaging.utils import canonicalize_name, parse_sdist_filename, parse_wheel_filename
+from packaging.version import Version
+
+PYTHONS = {"cp313", "cp314"}
+PLATFORMS = {"linux_x86_64", "linux_aarch64", "macos_x86_64", "macos_arm64", "win_amd64"}
+PACKAGE_FILES = {
+    "pythonnative/py.typed",
+    "pythonnative/native/yoga/python.cpp",
+    "pythonnative/native/yoga/yoga/Yoga.h",
+    "pythonnative/native/yoga/yoga/YGNode.cpp",
+    "pythonnative/native/ios/Package.swift",
+    "pythonnative/templates/android_template/gradlew",
+    "pythonnative/devserver/static/yoga/binaries/yoga-wasm-base64-esm.js",
+}
+
+
+def platform_family(platform: str) -> str:
+    """Map portable wheel tags to the host targets in the release matrix."""
+    match = re.fullmatch(r"manylinux_2_(\d+)_(x86_64|aarch64)", platform)
+    if match and int(match[1]) <= 28:
+        return f"linux_{match[2]}"
+    match = re.fullmatch(r"macosx_(\d+)_(\d+)_(x86_64|arm64)", platform)
+    if match and (int(match[1]), int(match[2])) <= (11, 0):
+        return f"macos_{match[3]}"
+    if platform == "win_amd64":
+        return platform
+    raise ValueError(f"Unsupported release platform tag: {platform}")
+
+
+def check_metadata(data: bytes, version: Version) -> None:
+    """Require archive metadata to agree with the selected release."""
+    metadata = BytesParser().parsebytes(data)
+    if canonicalize_name(metadata.get("Name", "")) != "pythonnative":
+        raise ValueError("Distribution metadata has the wrong project name")
+    if metadata.get("Version") != str(version):
+        raise ValueError("Distribution metadata has the wrong version")
+
+
+def check_distributions(directory: Path, expected_version: str) -> None:
+    """Validate the full wheel matrix and its single source distribution."""
+    version = Version(expected_version)
+    expected = {(python, platform) for python in PYTHONS for platform in PLATFORMS}
+    seen: set[tuple[str, str]] = set()
+    sdists = 0
+    for path in sorted(directory.iterdir()):
+        if path.name.endswith(".whl"):
+            name, wheel_version, build, tags = parse_wheel_filename(path.name)
+            if name != "pythonnative" or wheel_version != version or build:
+                raise ValueError(f"Unexpected wheel name/version/build: {path.name}")
+            targets = set()
+            for tag in tags:
+                if tag.interpreter not in PYTHONS or tag.abi != tag.interpreter:
+                    raise ValueError(f"Unsupported Python/ABI tag: {tag}")
+                targets.add((tag.interpreter, platform_family(tag.platform)))
+            if len(targets) != 1 or targets & seen:
+                raise ValueError(f"Duplicate or ambiguous wheel target: {path.name}")
+            seen.update(targets)
+            with zipfile.ZipFile(path) as archive:
+                names = set(archive.namelist())
+                metadata_path = f"pythonnative-{version}.dist-info/METADATA"
+                check_metadata(archive.read(metadata_path), version)
+                wheel = BytesParser().parsebytes(archive.read(metadata_path.replace("METADATA", "WHEEL")))
+                archive_tags = set().union(*(parse_tag(tag) for tag in wheel.get_all("Tag", [])))
+                if wheel.get("Root-Is-Purelib") != "false" or archive_tags != tags:
+                    raise ValueError(f"Wheel metadata disagrees with binary platform tags: {path.name}")
+                suffix = ".pyd" if next(iter(targets))[1] == "win_amd64" else ".so"
+                if not any(n.startswith("pythonnative/_yoga.") and n.endswith(suffix) for n in names):
+                    raise ValueError(f"Missing compiled Yoga extension: {path.name}")
+                missing = PACKAGE_FILES - names
+                if missing:
+                    raise ValueError(f"Missing package resources in {path.name}: {sorted(missing)}")
+        elif path.name.endswith(".tar.gz"):
+            name, sdist_version = parse_sdist_filename(path.name)
+            if name != "pythonnative" or sdist_version != version:
+                raise ValueError(f"Unexpected source distribution: {path.name}")
+            sdists += 1
+            with tarfile.open(path) as archive:
+                prefix = f"pythonnative-{version}/"
+                names = set(archive.getnames())
+                required = {prefix + "src/" + name for name in PACKAGE_FILES}
+                required |= {prefix + "setup.py", prefix + "tests/test_layout.py"}
+                if missing := required - names:
+                    raise ValueError(f"Incomplete source distribution: {sorted(missing)}")
+                metadata_file = archive.extractfile(prefix + "PKG-INFO")
+                project_file = archive.extractfile(prefix + "pyproject.toml")
+                if metadata_file is None or project_file is None:
+                    raise ValueError("Source distribution is missing package metadata")
+                check_metadata(metadata_file.read(), version)
+                if tomllib.loads(project_file.read().decode())["project"]["version"] != str(version):
+                    raise ValueError("Source version disagrees with release version")
+        else:
+            raise ValueError(f"Unexpected release artifact: {path.name}")
+    if sdists != 1 or seen != expected:
+        raise ValueError(f"Incomplete release: {sdists} sdists; missing wheel targets: {sorted(expected - seen)}")
+
+
+def main() -> None:
+    """Validate release artifacts selected by the workflow."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+    check_distributions(args.directory, args.version)
+    print(f"Validated {len(PYTHONS) * len(PLATFORMS)} wheels and one sdist for {args.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cibuildwheel.toml
+++ b/scripts/cibuildwheel.toml
@@ -1,0 +1,27 @@
+# Kept outside pyproject.toml so the current workflow can also build an
+# existing release's unmodified sdist, including tags predating cibuildwheel.
+[tool.cibuildwheel]
+build = ["cp313-*", "cp314-*"]
+skip = ["*-musllinux*", "*-win32", "*-manylinux_i686"]
+archs = ["native"]
+test-requires = ["pytest>=8"]
+# Install the repaired wheel into a fresh environment and copy just this
+# test file to a temporary directory, outside the source checkout.
+test-sources = ["tests/test_layout.py"]
+test-command = [
+  "python -c \"import pythonnative; from importlib.metadata import version; from pathlib import Path; assert 'site-packages' in Path(pythonnative.__file__).parts; assert pythonnative.__version__ == version('pythonnative')\"",
+  "python -m pytest -q tests/test_layout.py",
+  "pn --help",
+]
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
+
+[tool.cibuildwheel.windows]
+# These flags also make v0.40.0's C API available to ctypes without patching
+# the tagged source. setup.py supplies them for future source builds.
+environment = { CL = "/D_WINDLL", LINK = "/EXPORT:pn_yoga_callback /EXPORT:pn_yoga_measure" }

--- a/scripts/release-assets.py
+++ b/scripts/release-assets.py
@@ -1,0 +1,43 @@
+"""Preserve the exact distribution bytes across retries of a PyPI upload."""
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def sync_assets(tag: str, directory: Path) -> None:
+    """Upload new assets and reuse existing ones without overwriting releases.
+
+    Build timestamps can change archive hashes. Store files on the GitHub
+    release before publishing to PyPI, then reuse those same bytes on recovery.
+    The workflow validates the resulting directory again before publishing.
+    """
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--json", "assets"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    existing = {asset["name"] for asset in json.loads(result.stdout)["assets"]}
+    for path in sorted(directory.iterdir()):
+        if path.name in existing:
+            subprocess.run(
+                ["gh", "release", "download", tag, "--pattern", path.name, "--dir", str(directory), "--clobber"],
+                check=True,
+            )
+        else:
+            subprocess.run(["gh", "release", "upload", tag, str(path)], check=True)
+
+
+def main() -> None:
+    """Synchronize the selected release's distribution assets."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag")
+    parser.add_argument("directory", type=Path)
+    args = parser.parse_args()
+    sync_assets(args.tag, args.directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ setup(
             include_dirs=[str(root)],
             language="c++",
             extra_compile_args=["/std:c++20"] if os.name == "nt" else ["-std=c++20"],
+            # ctypes loads Yoga's C API and our measurement callbacks from
+            # the extension DLL, not just Python's module initializer.
+            define_macros=[("_WINDLL", "1")] if os.name == "nt" else [],
+            export_symbols=["pn_yoga_callback", "pn_yoga_measure"] if os.name == "nt" else [],
         )
     ]
 )

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -1,0 +1,160 @@
+"""Distribution validation and partial-upload recovery regressions."""
+
+import importlib.util
+import io
+import json
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def load_script(name: str) -> ModuleType:
+    path = Path(__file__).resolve().parents[1] / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = load_script("check-distributions")
+assets = load_script("release-assets")
+VERSION = "0.40.0"
+METADATA = f"Metadata-Version: 2.4\nName: pythonnative\nVersion: {VERSION}\n"
+PLATFORMS = [
+    "manylinux_2_28_x86_64",
+    "manylinux_2_28_aarch64",
+    "macosx_11_0_x86_64",
+    "macosx_11_0_arm64",
+    "win_amd64",
+]
+
+
+def wheel_files(python: str, platform: str) -> dict[str, bytes]:
+    suffix = "pyd" if platform == "win_amd64" else "so"
+    return {
+        **dict.fromkeys(checker.PACKAGE_FILES, b"resource"),
+        f"pythonnative/_yoga.{python}.{suffix}": b"native library",
+        f"pythonnative-{VERSION}.dist-info/METADATA": METADATA.encode(),
+        f"pythonnative-{VERSION}.dist-info/WHEEL": (
+            f"Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: {python}-{python}-{platform}\n".encode()
+        ),
+    }
+
+
+def write_wheel(path: Path, files: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name, data in files.items():
+            archive.writestr(name, data)
+
+
+@pytest.fixture
+def distributions(tmp_path: Path) -> Path:
+    for python in ("cp313", "cp314"):
+        for platform in PLATFORMS:
+            write_wheel(
+                tmp_path / f"pythonnative-{VERSION}-{python}-{python}-{platform}.whl",
+                wheel_files(python, platform),
+            )
+    source_files = {
+        **dict.fromkeys(("src/" + name for name in checker.PACKAGE_FILES), b"source"),
+        "setup.py": b"build configuration",
+        "tests/test_layout.py": b"layout tests",
+        "PKG-INFO": METADATA.encode(),
+        "pyproject.toml": f'[project]\nversion = "{VERSION}"\n'.encode(),
+    }
+    with tarfile.open(tmp_path / f"pythonnative-{VERSION}.tar.gz", "w:gz") as archive:
+        for name, data in source_files.items():
+            info = tarfile.TarInfo(f"pythonnative-{VERSION}/{name}")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+    return tmp_path
+
+
+def test_complete_distribution_matrix(distributions: Path) -> None:
+    checker.check_distributions(distributions, VERSION)
+
+
+def test_original_linux_wheel_rejection(distributions: Path) -> None:
+    path = next(distributions.glob("*cp314-cp314-manylinux_2_28_x86_64.whl"))
+    path.rename(path.with_name(path.name.replace("manylinux_2_28", "linux")))
+    with pytest.raises(ValueError, match="Unsupported release platform tag: linux_x86_64"):
+        checker.check_distributions(distributions, VERSION)
+
+
+@pytest.mark.parametrize("pattern", ["*cp313-cp313-win_amd64.whl", "*.tar.gz"])
+def test_missing_artifact_blocks_publish(distributions: Path, pattern: str) -> None:
+    next(distributions.glob(pattern)).unlink()
+    with pytest.raises(ValueError, match="Incomplete release"):
+        checker.check_distributions(distributions, VERSION)
+
+
+@pytest.mark.parametrize("damage", ["version", "tags", "pure", "extension", "resource"])
+def test_bad_wheel_contents_block_publish(distributions: Path, damage: str) -> None:
+    path = next(distributions.glob("*cp313-cp313-win_amd64.whl"))
+    files = wheel_files("cp313", "win_amd64")
+    metadata = f"pythonnative-{VERSION}.dist-info/METADATA"
+    wheel = f"pythonnative-{VERSION}.dist-info/WHEEL"
+    if damage == "version":
+        files[metadata] = files[metadata].replace(b"0.40.0", b"0.39.0")
+    elif damage == "tags":
+        files[wheel] = files[wheel].replace(b"win_amd64", b"linux_x86_64")
+    elif damage == "pure":
+        files[wheel] = files[wheel].replace(b"false", b"true")
+    elif damage == "extension":
+        del files["pythonnative/_yoga.cp313.pyd"]
+    else:
+        del files["pythonnative/native/yoga/yoga/Yoga.h"]
+    write_wheel(path, files)
+    with pytest.raises(ValueError):
+        checker.check_distributions(distributions, VERSION)
+
+
+@pytest.mark.parametrize("platform", ["linux_x86_64", "any", "manylinux_2_39_x86_64", "macosx_15_0_arm64"])
+def test_incompatible_platforms(platform: str) -> None:
+    with pytest.raises(ValueError, match="Unsupported release platform"):
+        checker.platform_family(platform)
+
+
+def test_recovery_reuses_original_bytes_after_partial_upload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first = tmp_path / "pythonnative-0.40.0-cp313-cp313-win_amd64.whl"
+    second = tmp_path / "pythonnative-0.40.0.tar.gz"
+    first.write_bytes(b"original wheel")
+    second.write_bytes(b"original source")
+    remote: dict[str, bytes] = {}
+    fail_upload = True
+
+    def gh(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert command[:2] == ["gh", "release"]
+        action = command[2]
+        if action == "view":
+            return subprocess.CompletedProcess(command, 0, json.dumps({"assets": [{"name": n} for n in remote]}))
+        if action == "upload":
+            path = Path(command[4])
+            if fail_upload and path == second:
+                raise subprocess.CalledProcessError(1, command)
+            assert path.name not in remote, "Recovery must never overwrite a published asset"
+            remote[path.name] = path.read_bytes()
+        elif action == "download":
+            name = command[command.index("--pattern") + 1]
+            (Path(command[command.index("--dir") + 1]) / name).write_bytes(remote[name])
+        else:
+            pytest.fail(f"Unexpected gh command: {command}")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(assets.subprocess, "run", gh)
+    with pytest.raises(subprocess.CalledProcessError):
+        assets.sync_assets("v0.40.0", tmp_path)
+    assert remote == {first.name: b"original wheel"}
+    first.write_bytes(b"rebuilt wheel with a different timestamp")
+    fail_upload = False
+    assets.sync_assets("v0.40.0", tmp_path)
+    assert first.read_bytes() == b"original wheel"
+    assert remote[second.name] == b"original source"
+    assets.sync_assets("v0.40.0", tmp_path)
+    assert first.read_bytes() == b"original wheel"


### PR DESCRIPTION
## What

Replace the single Ubuntu host wheel with ten tested binary wheels for CPython 3.13/3.14 on Linux x86-64/ARM64, macOS Intel/Apple Silicon, and Windows x64. Add recovery of an existing release tag after a failed publication.

## Why

The Yoga C++ extension changed the package from pure Python to platform-specific binaries. Release [33994259141](https://github.com/pythonnative/pythonnative/actions/runs/33994259141) created `v0.40.0`, but PyPI rejected its `linux_x86_64` wheel. Version 0.40.0 is still missing from PyPI.

## How

- Separate semantic-release version creation, distribution builds, and publishing. Keep version and lockfile updates in the tagged release commit.
- Share the cibuildwheel matrix between PR checks and releases. Build every wheel from the source archive, repair Linux/macOS wheels, install each wheel in isolation, and run the 79 Yoga layout tests plus a CLI smoke test.
- Require the complete matrix, matching versions and platform metadata, bundled native resources, and strict Twine checks before publishing.
- Export Yoga's C API and measurement callbacks on Windows. Build flags also support the original 0.40.0 source without patching its tag or source archive.
- Save validated files as GitHub release assets before PyPI uploads. Recovery reuses existing assets byte for byte and skips files already on PyPI.

## Testing

- Full local Python suite: 1,242 passed and 14 optional package checks skipped, including 14 new packaging/recovery regression cases.
- Built and repaired an Intel macOS 11 wheel from the source archive, passed strict Twine checks, installed it outside the checkout, and passed all 79 layout tests and the CLI smoke test.
- Ruff, Black, MyPy, and actionlint passed.
- In a temporary clone, verified a `build` commit produces no release and a subsequent simulated `fix` creates and locks 0.40.1 without producing a host wheel. No pushes or releases were performed by that rehearsal.
- [Recovery rehearsal](https://github.com/pythonnative/pythonnative/actions/runs/33995710696) passed: all ten wheels built from the original `v0.40.0` source, installed and tested, and the complete set passed resource/platform/version validation and strict Twine checks. Confirmed that the archive preserves the tagged build configuration and runtime source byte for byte. No publication was performed.
- All 29 PR checks passed, including the [distribution matrix](https://github.com/pythonnative/pythonnative/actions/runs/33995693740) and [iOS/Android E2E suite](https://github.com/pythonnative/pythonnative/actions/runs/33995693757).
- Infrastructure retries: the Intel build/tests passed initially, but GitHub's artifact service timed out during upload; rerunning the failed job passed. Android components-b used its existing suite retry after an emulator disconnect during cleanup and then passed. No tests or retry policies were changed.

## Risks/Impact

Linux wheels require glibc 2.28 or newer; macOS wheels target macOS 11 or newer. Windows wheels target x64. Mobile app builds continue to compile the bundled Yoga core themselves.

A source-only install of the unchanged 0.40.0 archive on Windows needs the documented export flags. Recovered Windows wheels include the exports; future source archives get them from `setup.py`.

## Docs/Follow-ups

Updated CONTRIBUTING.md with the actual release process, supported wheel targets, and recovery commands; removed the obsolete draft-release toggle description.

**Squash merge using this PR's `build(workflows): ...` title.** This is a packaging repair and should not create an unnecessary patch release. After merge, recover the existing version with:

```bash
gh workflow run release.yml --ref main -f tag=v0.40.0
```

Publication is intentionally deferred until after maintainer review and merge.
