### PR TITLE
ci(workflows): isolate semantic-release action outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,10 @@ jobs:
     permissions:
       contents: write
     outputs:
-      tag: ${{ steps.select.outputs.tag }}
-      commit: ${{ steps.select.outputs.commit }}
+      # PSR writes its own `tag` output even when released=false. Forward
+      # only outputs we explicitly set after selecting a source commit.
+      tag: ${{ steps.select.outputs.release_tag }}
+      commit: ${{ steps.select.outputs.release_commit }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,13 +69,13 @@ jobs:
           # Check the tag against package metadata without importing/building it.
           git show "$commit:pyproject.toml" > "$RUNNER_TEMP/release-project.toml"
           RELEASE_TAG="$tag" python -c 'import os, pathlib, tomllib; data = tomllib.loads((pathlib.Path(os.environ["RUNNER_TEMP"]) / "release-project.toml").read_text()); assert os.environ["RELEASE_TAG"] == "v" + data["project"]["version"]'
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_commit=$commit" >> "$GITHUB_OUTPUT"
 
   distributions:
     name: Build release distributions
     needs: release
-    if: needs.release.outputs.tag != ''
+    if: needs.release.outputs.tag != '' && needs.release.outputs.commit != ''
     uses: ./.github/workflows/wheels.yml
     with:
       source-ref: ${{ needs.release.outputs.commit }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 global-exclude *.pyc *.pyo .DS_Store
 include scripts/cibuildwheel.toml scripts/check-distributions.py scripts/release-assets.py
+include .github/workflows/release.yml
 recursive-exclude src/pythonnative/native .build/* .gradle/* .cxx/* build/* .swiftpm/* .kotlin/*
 prune src/pythonnative/native/android/build
 prune src/pythonnative/native/android/.gradle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "mypy>=1.10",
   "pytest>=8.0",
   "pytest-asyncio>=0.23",
+  "PyYAML>=6.0",
   "Pillow>=10.0",
   # `pn deps` and `pn run ios` shell out to `sys.executable -m pip` to
   # resolve and vendor the app's [requirements].packages for the device

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,108 @@
+"""Exercise the actual release-selection shell step and its job outputs."""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(os.name == "nt" or not shutil.which("bash"), reason="Release selection runs on Ubuntu")
+
+
+@pytest.fixture
+def release_repo(tmp_path: Path) -> Path:
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "-b", "main")
+    git("config", "user.name", "Release test")
+    git("config", "user.email", "release-test@example.invalid")
+    git("config", "commit.gpgsign", "false")
+    git("config", "core.hooksPath", "/dev/null")
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.40.0"\n')
+    git("add", "pyproject.toml")
+    git("commit", "-m", "chore(release): v0.40.0")
+    git("tag", "v0.40.0")
+    git("update-ref", "refs/remotes/origin/main", "HEAD")
+    git("commit", "--allow-empty", "-m", "build(workflows): repair publishing")
+
+    commands = tmp_path / "commands"
+    commands.mkdir()
+    (commands / "python").symlink_to(sys.executable)
+    # Keep the test local: replace only external tools, retaining real Git and
+    # the exact shell step from release.yml. PSR always appends its outputs,
+    # including the existing tag when it reports released=false.
+    stubs = {
+        "uv": "#!/bin/sh\nexit 0\n",
+        "gh": "#!/bin/sh\necho false\n",
+        "semantic-release": f"#!{sys.executable}\n"
+        + """import os
+from pathlib import Path
+import subprocess
+new_release = os.environ['TEST_RELEASE_MODE'] == 'new'
+version = '0.40.1' if new_release else '0.40.0'
+if new_release:
+    Path('pyproject.toml').write_text('[project]\\nversion = "0.40.1"\\n')
+    subprocess.run(['git', 'commit', '-am', 'chore(release): v0.40.1'], check=True)
+    subprocess.run(['git', 'tag', 'v0.40.1'], check=True)
+with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+    output.write(f'released={str(new_release).lower()}\\nversion={version}\\ntag=v{version}\\n')
+""",
+    }
+    for name, content in stubs.items():
+        path = commands / name
+        path.write_text(content)
+        path.chmod(0o755)
+    return tmp_path
+
+
+def run_selection(repo: Path, mode: str, recovery_tag: str = "") -> tuple[dict[str, str], dict[str, str]]:
+    workflow: dict[str, Any] = yaml.safe_load(
+        (Path(__file__).resolve().parents[1] / ".github/workflows/release.yml").read_text()
+    )
+    job = workflow["jobs"]["release"]
+    step = next(step for step in job["steps"] if step.get("id") == "select")
+    output_file = repo / "outputs"
+    output_file.touch()
+    env = {
+        **os.environ,
+        "PATH": str(repo / "commands") + os.pathsep + os.environ["PATH"],
+        "GITHUB_OUTPUT": str(output_file),
+        "RUNNER_TEMP": str(repo),
+        "RECOVERY_TAG": recovery_tag,
+        "TEST_RELEASE_MODE": mode,
+    }
+    subprocess.run(["bash", "-e", "-o", "pipefail", "-c", step["run"]], cwd=repo, env=env, check=True)
+    step_outputs = dict(line.split("=", 1) for line in output_file.read_text().splitlines())
+    job_outputs = {}
+    for name, expression in job["outputs"].items():
+        match = re.fullmatch(r"\$\{\{ steps\.select\.outputs\.(\w+) \}\}", expression)
+        assert match is not None
+        job_outputs[name] = step_outputs.get(match[1], "")
+    return step_outputs, job_outputs
+
+
+def test_no_release_does_not_forward_semantic_release_tag(release_repo: Path) -> None:
+    step_outputs, job_outputs = run_selection(release_repo, "none")
+    assert step_outputs["released"] == "false"
+    assert step_outputs["tag"] == "v0.40.0"
+    assert job_outputs == {"tag": "", "commit": ""}
+
+
+def test_new_release_selects_the_new_tagged_commit(release_repo: Path) -> None:
+    _, job_outputs = run_selection(release_repo, "new")
+    commit = subprocess.check_output(["git", "rev-parse", "v0.40.1^{commit}"], cwd=release_repo, text=True).strip()
+    assert job_outputs == {"tag": "v0.40.1", "commit": commit}
+
+
+def test_recovery_selects_existing_source_instead_of_main(release_repo: Path) -> None:
+    _, job_outputs = run_selection(release_repo, "none", "v0.40.0")
+    commit = subprocess.check_output(["git", "rev-parse", "v0.40.0^{commit}"], cwd=release_repo, text=True).strip()
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=release_repo, text=True).strip()
+    assert commit != head
+    assert job_outputs == {"tag": "v0.40.0", "commit": commit}

--- a/uv.lock
+++ b/uv.lock
@@ -981,6 +981,7 @@ dev = [
     { name = "pip" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 docs = [
@@ -1006,6 +1007,7 @@ dev = [
     { name = "pip", specifier = ">=24.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.5" },
 ]
 docs = [


### PR DESCRIPTION
## What

Keep semantic-release's own GitHub Actions outputs separate from the tag and source commit selected for publishing. Require both a tag and an explicit source commit before starting distribution builds.

## Why

After #82 merged, semantic-release correctly decided that the `build` commit didn't warrant a new version, but it still appended `tag=v0.40.0` and `released=false` to `GITHUB_OUTPUT`. The workflow forwarded that tag while its commit output was empty, which started distribution builds using the fallback main commit. I canceled [that run](https://github.com/pythonnative/pythonnative/actions/runs/34008947389) before publication.

Explicit-tag recovery selects the original commit correctly and is unaffected. [Recovery run 34009001457](https://github.com/pythonnative/pythonnative/actions/runs/34009001457) succeeded: 0.40.0 is now on PyPI with ten wheels and its source archive. All eleven hashes match the GitHub release assets, the original tag/source are preserved, and fresh binary-only PyPI installations on Python 3.13 and 3.14 each passed all 79 layout tests and the CLI version check.

## How

- Set and forward our own `release_tag` and `release_commit` step outputs.
- Gate distribution builds on both job outputs being present.
- Exercise the actual YAML shell step with real Git repositories and controlled external tools for no-release, new-release, and existing-tag recovery cases.
- Add PyYAML to contributor tooling to read the workflow in tests. Include the workflow as test input in the source archive. No runtime dependencies or dependency versions change.

## Testing

- All three selection regressions pass. Against the merged workflow, the no-release test fails while the other two pass.
- Replayed both versions with the real pinned python-semantic-release 9.21.2 and `GITHUB_OUTPUT` set in a temporary clone. The original forwards `tag=v0.40.0` with no commit; the fix forwards neither. Pushing and GitHub release creation were disabled for that rehearsal.
- Full Python suite, Ruff, Black, MyPy, and actionlint passed locally.
- CI Python 3.13/3.14 checks, native unit tests, docs, PR lint, and Linux/Windows wheel builds passed. The remaining macOS wheel and device checks are running.

## Risks/Impact

No library behavior or version changes. New releases and manual recovery still select the exact tagged source. Use this PR's `ci(workflows): ...` title for the squash merge so this correction doesn't trigger a version bump.

## Docs/Follow-ups

This restores the release behavior already documented in CONTRIBUTING.md. The separate explicit-tag recovery has finished successfully; this PR prevents the automatic no-release path from starting another build.
