### PR TITLE
docs(mkdocs): cover IS_WEB in the platform-specific code FAQ

### DIFF
--- a/docs/meta/faq.md
+++ b/docs/meta/faq.md
@@ -20,24 +20,24 @@ with the native UI through a versioned bridge.
 
 Yes. Two patterns:
 
-- **Branch on `IS_ANDROID` / `IS_IOS` / `IS_DESKTOP`** for small
+- **Branch on `IS_ANDROID` / `IS_IOS` / `IS_WEB`** for small
   differences inside a shared component:
 
     ```python
-    from pythonnative.utils import IS_ANDROID, IS_IOS, IS_DESKTOP
+    from pythonnative.utils import IS_ANDROID, IS_IOS, IS_WEB
 
     if IS_ANDROID:
         ...
     elif IS_IOS:
         ...
-    elif IS_DESKTOP:
+    elif IS_WEB:
         ...
     ```
 
-    `pn preview` runs the app with `IS_DESKTOP` set; see the
-    [Desktop preview guide](../guides/desktop-preview.md).
-    For a declarative alternative, use `Platform.select({...})`; see the
-    [Platform API](../api/platform.md).
+    `pn preview` runs the app with `IS_WEB` set; see the
+    [Browser preview guide](../guides/browser-preview.md).
+    For a declarative alternative, use
+    [`Platform.select`][pythonnative.platform.Platform.select].
 
 - **Per-platform native modules** for larger pieces (a custom widget,
   a device API). Implement once per platform behind a single Python

--- a/docs/meta/faq.md
+++ b/docs/meta/faq.md
@@ -34,10 +34,12 @@ Yes. Two patterns:
         ...
     ```
 
-    `pn preview` runs the app with `IS_WEB` set; see the
+    `pn preview` and `pn start` set `PN_PLATFORM=web`, so `IS_WEB` is
+    `True` in the browser preview; see the
     [Browser preview guide](../guides/browser-preview.md).
     For a declarative alternative, use
-    [`Platform.select`][pythonnative.platform.Platform.select].
+    [`Platform.select`][pythonnative.platform.Platform.select] with the
+    `"web"` key.
 
 - **Per-platform native modules** for larger pieces (a custom widget,
   a device API). Implement once per platform behind a single Python

--- a/docs/meta/faq.md
+++ b/docs/meta/faq.md
@@ -20,17 +20,24 @@ with the native UI through a versioned bridge.
 
 Yes. Two patterns:
 
-- **Branch on `IS_ANDROID` / `IS_IOS`** for small differences inside
-  a shared component:
+- **Branch on `IS_ANDROID` / `IS_IOS` / `IS_DESKTOP`** for small
+  differences inside a shared component:
 
     ```python
-    from pythonnative.utils import IS_ANDROID, IS_IOS
+    from pythonnative.utils import IS_ANDROID, IS_IOS, IS_DESKTOP
 
     if IS_ANDROID:
         ...
     elif IS_IOS:
         ...
+    elif IS_DESKTOP:
+        ...
     ```
+
+    `pn preview` runs the app with `IS_DESKTOP` set; see the
+    [Desktop preview guide](../guides/desktop-preview.md).
+    For a declarative alternative, use `Platform.select({...})`; see the
+    [Platform API](../api/platform.md).
 
 - **Per-platform native modules** for larger pieces (a custom widget,
   a device API). Implement once per platform behind a single Python


### PR DESCRIPTION
## What

Add browser preview to the FAQ's platform-specific branching example.

## Why

The example only covered Android and iOS, leaving browser preview behavior
unexplained.

## How

Import and branch on `IS_WEB` alongside `IS_ANDROID` and `IS_IOS`. Explain that
`pn preview` and `pn start` set `PN_PLATFORM=web`. Link to the browser preview
guide and `Platform.select`, including its `"web"` key.

## Testing

- `uv run --locked --group docs mkdocs build --strict` passes with this branch
  merged locally into current `main`.
- Checked the rendered FAQ snippet and the browser preview guide and
  `Platform.select` links.

## Risks/Impact

Documentation only. The FAQ still distinguishes browser preview as a
development tool and Android and iOS as app deployment targets.

## Docs/Follow-ups

Updates the platform-specific code FAQ. No runtime changes are needed.

Closes #59
