### PR TITLE
fix(net): preserve custom content type regardless of header casing

### DIFF
--- a/src/pythonnative/net.py
+++ b/src/pythonnative/net.py
@@ -147,7 +147,7 @@ async def fetch(
 
     Args:
         url: Target URL. Relative URLs are not supported.
-        method: HTTP method (``"GET"``, ``"POST"``, ``"PUT"`` …).
+        method: HTTP method (``GET``, ``POST``, ``PUT`` …).
         headers: Optional request headers.
         body: Request body. ``bytes`` are sent as-is; ``str`` is
             UTF-8 encoded; ``dict`` is JSON-encoded with a
@@ -203,7 +203,8 @@ def _build_request(
         payload = body.encode("utf-8")
     elif isinstance(body, Mapping):
         payload = json.dumps(body, default=str).encode("utf-8")
-        header_dict.setdefault("Content-Type", "application/json")
+        if not any(name.lower() == "content-type" for name in header_dict):
+            header_dict["Content-Type"] = "application/json"
     else:
         raise TypeError(f"Unsupported body type: {type(body)!r}")
 

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -213,13 +213,10 @@ def test_custom_content_type_is_preserved_regardless_of_casing(header_name: str)
         body={"name": "Ada"},
         params=None,
     )
-    content_types = [
-        value
-        for name, value in request.header_items()
-        if name.lower() == "content-type"
-    ]
+    content_types = [value for name, value in request.header_items() if name.lower() == "content-type"]
     assert content_types == ["application/merge-patch+json"]
     assert original_headers == {header_name: "application/merge-patch+json"}
+    assert isinstance(request.data, bytes)
     assert json.loads(request.data.decode("utf-8")) == {"name": "Ada"}
 
 
@@ -231,10 +228,7 @@ def test_mapping_body_defaults_to_application_json() -> None:
         body={"name": "Ada"},
         params=None,
     )
-    content_types = [
-        value
-        for name, value in request.header_items()
-        if name.lower() == "content-type"
-    ]
+    content_types = [value for name, value in request.header_items() if name.lower() == "content-type"]
     assert content_types == ["application/json"]
+    assert isinstance(request.data, bytes)
     assert json.loads(request.data.decode("utf-8")) == {"name": "Ada"}

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -11,7 +11,7 @@ from typing import Generator
 
 import pytest
 
-from pythonnative.net import HTTPError, Response, fetch
+from pythonnative.net import HTTPError, Response, _build_request, fetch
 
 # ======================================================================
 # Mini HTTP server fixture
@@ -198,3 +198,43 @@ def test_unreachable_host_raises_oserror() -> None:
 
     with pytest.raises(OSError):
         asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    ["Content-Type", "content-type", "CONTENT-TYPE", "Content-type"],
+)
+def test_custom_content_type_is_preserved_regardless_of_casing(header_name: str) -> None:
+    original_headers = {header_name: "application/merge-patch+json"}
+    request = _build_request(
+        url="https://example.com/users",
+        method="POST",
+        headers=original_headers,
+        body={"name": "Ada"},
+        params=None,
+    )
+    content_types = [
+        value
+        for name, value in request.header_items()
+        if name.lower() == "content-type"
+    ]
+    assert content_types == ["application/merge-patch+json"]
+    assert original_headers == {header_name: "application/merge-patch+json"}
+    assert json.loads(request.data.decode("utf-8")) == {"name": "Ada"}
+
+
+def test_mapping_body_defaults_to_application_json() -> None:
+    request = _build_request(
+        url="https://example.com/users",
+        method="POST",
+        headers=None,
+        body={"name": "Ada"},
+        params=None,
+    )
+    content_types = [
+        value
+        for name, value in request.header_items()
+        if name.lower() == "content-type"
+    ]
+    assert content_types == ["application/json"]
+    assert json.loads(request.data.decode("utf-8")) == {"name": "Ada"}


### PR DESCRIPTION
## Summary

`_build_request()` used `header_dict.setdefault("Content-Type", "application/json")` when encoding a mapping body. That lookup is case-sensitive, so a caller-supplied `content-type` / `CONTENT-TYPE` header was ignored and `urllib.request.Request` later collapsed both names, overwriting the custom value with `application/json`.

This change only adds the JSON default when no existing header name matches `content-type` case-insensitively. The caller mapping is copied first, so it is left unchanged.

Fixes #87

## Motivation

Issue #87 documents that `headers={"content-type": "application/merge-patch+json"}` with a dict body produced `Content-type: application/json` on the request. That can change how an API interprets the payload.

## Implementation

In `src/pythonnative/net.py`, replace `setdefault("Content-Type", ...)` with:

```python
if not any(name.lower() == "content-type" for name in header_dict):
    header_dict["Content-Type"] = "application/json"
```

JSON encoding of mapping bodies is unchanged.

## Testing

Added parameterized tests in `tests/test_net.py` that construct requests with `_build_request()` (no network):

- `Content-Type`, `content-type`, `CONTENT-TYPE`, and `Content-type` all keep `application/merge-patch+json`
- exactly one content-type header remains on the request
- the original headers mapping is unchanged
- the body still decodes to the original JSON object
- a mapping body with no content-type still gets `application/json`

Checks performed in this environment:

- Isolated reproduction of `_build_request` header assembly on Python 3.12 (project requires 3.13 for the full package import). Result: all four casings preserved a single `application/merge-patch+json` header; default path still sets `application/json`.
- Full `uv run pytest tests/test_net.py -q` and `./scripts/check.sh` were not run here because Python 3.13 is not available on this runner. Please rely on CI for those.